### PR TITLE
Add OWASP dependency-check reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ clean:
 	rm -rf ./build-*
 	rm -rf ./build.log-*
 
+.PHONY: security-check
+security-check:
+	mvn org.owasp:dependency-check-maven:check -DassemblyAnalyzerEnabled=false -DfailBuildOnCVSS=0
+
 .PHONY: test-unit
 test-unit:
 	echo "make test-unit does nothing, use build target instead"
@@ -37,7 +41,10 @@ endif
 	rm -rf $(tmpdir)
 
 .PHONY: build
-build: clean coverage
+build: clean
+	mvn versions:set -DnewVersion=$(version) -DgenerateBackupPoms=false
+	mvn package
+	cp ./target/$(artifact_name)-$(version).jar ./$(artifact_name).jar
 
 .PHONY: dist
 dist: clean coverage package

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,7 @@ endif
 	rm -rf $(tmpdir)
 
 .PHONY: build
-build: clean
-	mvn versions:set -DnewVersion=$(version) -DgenerateBackupPoms=false
-	mvn package
-	cp ./target/$(artifact_name)-$(version).jar ./$(artifact_name).jar
+build: clean coverage
 
 .PHONY: dist
 dist: clean coverage package

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,13 @@
             ${project.build.directory}/site/jacoco-it/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
         <sonar.jacoco.reports>${project.build.directory}/site</sonar.jacoco.reports>
+        <dependency-check-maven.version>7.3.0</dependency-check-maven.version>
+        <sonar.dependencyCheck.htmlReportPath>
+            ${project.build.directory}/dependency-check-report.html
+        </sonar.dependencyCheck.htmlReportPath>
+        <sonar.dependencyCheck.jsonReportPath>
+            ${project.build.directory}/dependency-check-report.json
+        </sonar.dependencyCheck.jsonReportPath>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -223,6 +230,27 @@
                             <!-- Sets the output directory for the code coverage report. -->
                             <outputDirectory>${sonar.jacoco.reports}/jacoco-it</outputDirectory>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>${dependency-check-maven.version}</version>
+                <configuration>
+                    <formats>
+                        <format>html</format>
+                        <format>json</format>
+                    </formats>
+                    <suppressionFiles>
+                        <suppressionFile>suppress.xml</suppressionFile>
+                    </suppressionFiles>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/suppress.xml
+++ b/suppress.xml
@@ -2,7 +2,7 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <suppress>
         <notes><![CDATA[
-          File name: structured-logging-1.9.5.jar
+          File name: structured-logging-1.9.14.jar
           ]]></notes>
         <packageUrl regex="true">^pkg:maven/uk\.gov\.companieshouse/structured\-logging@.*$</packageUrl>
         <cpe>cpe:/a:apache:log4j</cpe>

--- a/suppress.xml
+++ b/suppress.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+          File name: structured-logging-1.9.5.jar
+          ]]></notes>
+        <packageUrl regex="true">^pkg:maven/uk\.gov\.companieshouse/structured\-logging@.*$</packageUrl>
+        <cpe>cpe:/a:apache:log4j</cpe>
+    </suppress>
+
+    <suppress until="2023-05-25Z">
+        <notes><![CDATA[
+           File name: spring-web-5.3.22.jar
+
+           Suppressed for 6 months
+
+           A JIRA ticket has been created to track this vulnerability - https://companieshouse.atlassian.net/browse/DEBT-1742
+
+           It is unlikely that this library will be updated and therefore that the suppression will be removed.
+           ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-web@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
+</suppressions>


### PR DESCRIPTION
- add dependency-check to 'verify' goal
- add suppression file with rules from another CHS service using it
- upload results to sonarqube server

See uploaded HTML report here (https://code-analysis.platform.aws.chdev.org/project/extension/dependencycheck/report_page?id=uk.gov.companieshouse%3Apsc-filing-api&qualifier=TRK)
See also project security hotspots, including those found by dependency-check, listed here (https://code-analysis.platform.aws.chdev.org/project/issues?id=uk.gov.companieshouse%3Apsc-filing-api&resolved=false&sinceLeakPeriod=false&types=VULNERABILITY)