### PR TITLE
Add data model class diagrams

### DIFF
--- a/docs/Internal Data Model of PSC Classes.puml
+++ b/docs/Internal Data Model of PSC Classes.puml
@@ -98,40 +98,34 @@ end legend
                 -updatedAt: Instant
             }
 
+            class PscWithIdentification {
+                -identification: Identification
+            }
+          note "This models the RLE (corporate) and the \nORP (legal) types of PSC" as Note1
+          PscWithIdentification .. Note1
+
             class PscIndividual {
                 -countryOfResidence
-                -dateOfBirth: Date3Tuple
                 -nameElements: NameElements
                 -nationality
                 -residentialAddress: Address
                 -residentialAddressSameAsCorrespondenceAddress: Boolean
+                -dateOfBirth: Date3Tuple
                 -statementActionDate: LocalDate
                 -statementType
             }
-
-            class PscWithIdentification {
-                -identification: Identification
-            }
-
-          note "This models the RLE (corporate) and the \nORP (legal) types of PSC" as Note1
-
-          PscWithIdentification .. Note1
 
             class Links {
                 -self: URI
             }
 
-/'           note left of Psc::naturesOfControl
-                See public spec for full list
-            end note'/
-
-            Psc <|-- PscIndividual
             Psc <|-- PscWithIdentification
-            PscIndividual::nameElements o-- NameElements
+            Psc <|-- PscIndividual
+            NameElements -o PscIndividual::nameElements
             Identification -o PscWithIdentification::identification
             Psc::address o- Address
             Address --o PscIndividual::residentialAddress
-            PscIndividual::dateOfBirth o- Date3Tuple
+            PscIndividual::dateOfBirth o-- Date3Tuple
             Links -o Psc::links
             Statement::links o- Links
 

--- a/docs/Internal Data Model of PSC Classes.puml
+++ b/docs/Internal Data Model of PSC Classes.puml
@@ -1,0 +1,138 @@
+@startuml
+skinparam linetype poly
+skinparam nodesep 60 /' horizontal separator '/
+skinparam ranksep 50 /' vertical separator '/
+skinparam titleBorderRoundCorner 15
+skinparam titleBorderThickness 1
+skinparam titleBorderColor black
+skinparam titleBackgroundColor PaleTurquoise
+skinparam groupInheritance 1
+scale 1
+hide empty members
+'hide circle'
+skinparam titleFontSize 16
+
+title PSC Filing API: Internal Data Model Class Structure
+
+    package "model" {
+
+        package "entity" {
+
+            class Address {
+                -addressLine1
+                -addressLine2
+                -careOf
+                -country
+                -poBox
+                -postalCode
+                -premises
+                -region
+            }
+
+            class Date3Tuple {
+                -day:int
+                -month:int
+                -year:int
+            }
+            note right of Date3Tuple
+               day is null
+               for partial DOB
+            end note
+
+            class Identification {
+                -countryRegistered
+                -legalAuthority
+                -legalForm
+                -placeRegistered
+                -registrationNumber
+            }
+
+            class NamesElement {
+                -forename
+                -otherForenames
+                -surname
+                -title
+            }
+
+            class Links {
+                -URI: self
+                -URI: validationStatus?
+            }
+
+            abstract class PscFiling {
+                -address: Address
+                -addressSameAsRegisteredOfficeAddress: Boolean
+                -ceasedOn: LocalDate
+                -createdAt: Instant
+                -etag
+                -identification
+                -kind
+                -links: Links
+                -name
+                -naturesOfControl[1..*]
+                -notifiedOn: LocalDate
+                -referenceEtag
+                -referencePscId
+                -referencePscListEtag
+                -registerEntryDate: LocalDate
+                -updatedAt: Instant
+            }
+
+            class PscFilingIndividual {
+                -countryOfResidence
+                -dateOfBirth: Date3Tuple
+                -nameElements: NamesElement
+                -nationality
+                -residentialAddress: Address
+                -residentialAddressSameAsCorrespondenceAddress: Boolean
+                -statementActionDate: LocalDate
+                -statementType
+            }
+
+            class PscFilingRle {
+            }
+
+            class LegalIdentification {
+                legalAuthority
+                legalForm
+            }
+
+            class PscFilingOrp {
+            }
+
+            class Statement {
+                -actionDate: LocalDate
+                -createdAt: Instant
+                -kind
+                -links: Links
+            }
+
+            together {
+                class PscFilingIndividual
+                class PscFilingOrp
+                class PscFilingRle
+            }
+
+            together {
+                class Address
+                class Date3Tuple
+                class Identification
+                class NamesElement
+            }
+
+            PscFiling::address o-l- Address
+            PscFilingIndividual::residential_address o-- Address
+            PscFilingIndividual o-u- Date3Tuple
+            PscFilingIndividual o-u- Identification
+            PscFilingOrp o-u- Identification
+            PscFiling o-u- Links
+            PscFilingIndividual o-u- NamesElement
+            PscFiling <|-- PscFilingIndividual
+            PscFiling <|-- PscFilingOrp
+            PscFiling <|-- PscFilingRle
+            PscFilingRle::legalIdentification o-l- LegalIdentification
+        }
+    }
+
+
+@enduml

--- a/docs/Internal Data Model of PSC Classes.puml
+++ b/docs/Internal Data Model of PSC Classes.puml
@@ -1,18 +1,23 @@
 @startuml
 skinparam linetype poly
-skinparam nodesep 60 /' horizontal separator '/
+skinparam nodesep 100 /' horizontal separator '/
 skinparam ranksep 50 /' vertical separator '/
 skinparam titleBorderRoundCorner 15
 skinparam titleBorderThickness 1
 skinparam titleBorderColor black
-skinparam titleBackgroundColor PaleTurquoise
+skinparam titleBackgroundColor AliceBlue
 skinparam groupInheritance 1
 scale 1
 hide empty members
 'hide circle'
 skinparam titleFontSize 16
+skinparam legendBackgroundColor AliceBlue
 
 title PSC Filing API: Internal Data Model Class Structure
+legend right
+|=Revision |=Date |
+|    0.1    |     22/11/2022    |
+end legend
 
     package "model" {
 
@@ -47,7 +52,7 @@ title PSC Filing API: Internal Data Model Class Structure
                 -registrationNumber
             }
 
-            class NamesElement {
+            class NameElements {
                 -forename
                 -otherForenames
                 -surname
@@ -55,11 +60,10 @@ title PSC Filing API: Internal Data Model Class Structure
             }
 
             class Links {
-                -URI: self
-                -URI: validationStatus?
+                -self: URI
             }
 
-            abstract class PscFiling {
+            abstract class Psc {
                 -address: Address
                 -addressSameAsRegisteredOfficeAddress: Boolean
                 -ceasedOn: LocalDate
@@ -78,10 +82,14 @@ title PSC Filing API: Internal Data Model Class Structure
                 -updatedAt: Instant
             }
 
-            class PscFilingIndividual {
+           note left of Psc::naturesOfControl
+                See public spec for full list
+            end note
+
+            class PscIndividual {
                 -countryOfResidence
                 -dateOfBirth: Date3Tuple
-                -nameElements: NamesElement
+                -nameElements: NameElements
                 -nationality
                 -residentialAddress: Address
                 -residentialAddressSameAsCorrespondenceAddress: Boolean
@@ -89,48 +97,59 @@ title PSC Filing API: Internal Data Model Class Structure
                 -statementType
             }
 
-            class PscFilingRle {
+            class PscIdentified {
             }
-
-            class LegalIdentification {
-                legalAuthority
-                legalForm
-            }
-
-            class PscFilingOrp {
-            }
+           note "This models the RLE (corporate) and the \nORP (legal) types of PSC" as Note1
+           Note1 ... PscIdentified
 
             class Statement {
                 -actionDate: LocalDate
                 -createdAt: Instant
                 -kind
                 -links: Links
+                -referenceEtag
+                -referenceStatementId
+                -restrictionsNoticeWithdrawlReason
+                -statement
+                -updatedAt: Instant
             }
 
+
+          note left of Statement::referenceStatementId
+                Required for PSC09
+           end note
+
+          note left of Statement::statement
+                See public spec for full list
+           end note
+
+           Identification -[hidden] PscIdentified
+
+/'            Date3Tuple -[hidden] Address
+           Links -[hidden] Statement
+            PscIndividual -[hidden] PscIdentified
+
             together {
-                class PscFilingIndividual
-                class PscFilingOrp
-                class PscFilingRle
+                class PscIndividual
+                class PscIdentified
             }
 
             together {
                 class Address
                 class Date3Tuple
                 class Identification
-                class NamesElement
-            }
+                class NameElements
+            }'/
 
-            PscFiling::address o-l- Address
-            PscFilingIndividual::residential_address o-- Address
-            PscFilingIndividual o-u- Date3Tuple
-            PscFilingIndividual o-u- Identification
-            PscFilingOrp o-u- Identification
-            PscFiling o-u- Links
-            PscFilingIndividual o-u- NamesElement
-            PscFiling <|-- PscFilingIndividual
-            PscFiling <|-- PscFilingOrp
-            PscFiling <|-- PscFilingRle
-            PscFilingRle::legalIdentification o-l- LegalIdentification
+            Psc::address o-l- Address
+            PscIndividual::residential_address o-- Address
+            PscIndividual::dateOfBirth o-u- Date3Tuple
+            PscIdentified o-u- Identification
+            Psc::links o-u- Links
+            Statement::links o-u- Links
+            PscIndividual::nameElements o-u- NameElements
+            Psc <|-- PscIndividual
+            Psc <|-- PscIdentified
         }
     }
 

--- a/docs/Internal Data Model of PSC Classes.puml
+++ b/docs/Internal Data Model of PSC Classes.puml
@@ -7,7 +7,7 @@ skinparam titleBorderThickness 1
 skinparam titleBorderColor black
 skinparam titleBackgroundColor AliceBlue
 skinparam groupInheritance 1
-scale 1
+scale 800 width
 hide empty members
 'hide circle'
 skinparam titleFontSize 16
@@ -35,14 +35,14 @@ end legend
             }
 
             class Date3Tuple {
-                -day:int
+                -day:int {nullable}
                 -month:int
                 -year:int
             }
-            note right of Date3Tuple
+/'            note right of Date3Tuple
                day is null
                for partial DOB
-            end note
+            end note'/
 
             class Identification {
                 -countryRegistered
@@ -59,9 +59,25 @@ end legend
                 -title
             }
 
-            class Links {
-                -self: URI
+            class Statement {
+                -actionDate: LocalDate
+                -createdAt: Instant
+                -kind
+                -links: Links
+                -referenceEtag
+                -referenceStatementId
+                -restrictionsNoticeWithdrawlReason
+                -statement
+                -updatedAt: Instant
             }
+
+          note left of Statement::referenceStatementId
+                Required for PSC09
+           end note
+
+/'          note left of Statement::statement
+                See public spec for full list
+           end note'/
 
             abstract class Psc {
                 -address: Address
@@ -82,10 +98,6 @@ end legend
                 -updatedAt: Instant
             }
 
-           note left of Psc::naturesOfControl
-                See public spec for full list
-            end note
-
             class PscIndividual {
                 -countryOfResidence
                 -dateOfBirth: Date3Tuple
@@ -97,61 +109,33 @@ end legend
                 -statementType
             }
 
-            class PscIdentified {
-            }
-           note "This models the RLE (corporate) and the \nORP (legal) types of PSC" as Note1
-           Note1 ... PscIdentified
-
-            class Statement {
-                -actionDate: LocalDate
-                -createdAt: Instant
-                -kind
-                -links: Links
-                -referenceEtag
-                -referenceStatementId
-                -restrictionsNoticeWithdrawlReason
-                -statement
-                -updatedAt: Instant
+            class PscWithIdentification {
+                -identification: Identification
             }
 
+          note "This models the RLE (corporate) and the \nORP (legal) types of PSC" as Note1
 
-          note left of Statement::referenceStatementId
-                Required for PSC09
-           end note
+          PscWithIdentification .. Note1
 
-          note left of Statement::statement
+            class Links {
+                -self: URI
+            }
+
+/'           note left of Psc::naturesOfControl
                 See public spec for full list
-           end note
+            end note'/
 
-           Identification -[hidden] PscIdentified
-
-/'            Date3Tuple -[hidden] Address
-           Links -[hidden] Statement
-            PscIndividual -[hidden] PscIdentified
-
-            together {
-                class PscIndividual
-                class PscIdentified
-            }
-
-            together {
-                class Address
-                class Date3Tuple
-                class Identification
-                class NameElements
-            }'/
-
-            Psc::address o-l- Address
-            PscIndividual::residential_address o-- Address
-            PscIndividual::dateOfBirth o-u- Date3Tuple
-            PscIdentified o-u- Identification
-            Psc::links o-u- Links
-            Statement::links o-u- Links
-            PscIndividual::nameElements o-u- NameElements
             Psc <|-- PscIndividual
-            Psc <|-- PscIdentified
+            Psc <|-- PscWithIdentification
+            PscIndividual::nameElements o-- NameElements
+            Identification -o PscWithIdentification::identification
+            Psc::address o- Address
+            Address --o PscIndividual::residentialAddress
+            PscIndividual::dateOfBirth o- Date3Tuple
+            Links -o Psc::links
+            Statement::links o- Links
+
         }
     }
-
 
 @enduml

--- a/docs/Target Data Model of PSC Classes.puml
+++ b/docs/Target Data Model of PSC Classes.puml
@@ -100,10 +100,10 @@ endlegend
             class PscIndividualDto {
                 -countryOfResidence
                 -dateOfBirth: Date3TupleDto
-                -nameElements: NameElementsDto
                 -nationality
                 -residentialAddress: AddressDto
                 -residentialAddressSameAsCorrespondenceAddress: Boolean
+                -nameElements: NameElementsDto
             }
 
 /'           note "This models an individual PSC" as Note2

--- a/docs/Target Data Model of PSC Classes.puml
+++ b/docs/Target Data Model of PSC Classes.puml
@@ -1,20 +1,27 @@
 @startuml
 'https://plantuml.com/class-diagram
-'ortho
-skinparam linetype poly
+'ortho/polyline
+'skinparam linetype polyline
 skinparam nodesep 50 /' horizontal separator '/
-skinparam ranksep 50 /' vertical separator '/
+skinparam ranksep 100 /' vertical separator '/
 skinparam titleBorderRoundCorner 15
 skinparam titleBorderThickness 1
 skinparam titleBorderColor black
-skinparam titleBackgroundColor PaleTurquoise
+skinparam titleBackgroundColor AliceBlue
 skinparam groupInheritance 1
-scale 1
+skinparam legendBackgroundColor AliceBlue
+
+scale 800 width
 hide empty members
 'hide circle'
 skinparam titleFontSize 16
 
 title PSC Filing API: Target Data Model Class Structure
+
+legend right
+|=Revision |=Date |
+|    0.1    |     21/11/2022    |
+endlegend
 
     package "model" {
 
@@ -32,14 +39,15 @@ title PSC Filing API: Target Data Model Class Structure
             }
 
             class Date3TupleDto {
-                -day:int
+                -day:int {nullable}
                 -month:int
                 -year:int
             }
-            note right of Date3TupleDto
+
+/'             note left of Date3TupleDto
                day is null
                for partial DOB
-            end note
+            end note'/
 
             class IdentificationDto {
                 -countryRegistered
@@ -61,16 +69,16 @@ title PSC Filing API: Target Data Model Class Structure
                 -referenceStatementId
                 -restrictionsNoticeWithdrawlReason
                 -statementActionDate: LocalDate
-                -statementType []
+                -statementType
             }
 
           note left of PscStatementDto::referenceStatementId
                 Required for PSC09
            end note
 
-          note left of PscStatementDto::statementType
+/'          note left of PscStatementDto::statementType
                 See public spec for full list
-           end note            
+           end note'/
 
             abstract class PscDto {
                 -address: AddressDto
@@ -85,15 +93,9 @@ title PSC Filing API: Target Data Model Class Structure
                 -registerEntryDate: LocalDate
             }
 
-           note left of PscDto::naturesOfControl
+/'           note left of PscDto::naturesOfControl
                 See public spec for full list
-            end note
-
-/'            together {
-                class PscIndividualDto
-                class PscFilingCorporateDto
-                class PscFilingRleDto
-            }'/
+            end note'/
 
             class PscIndividualDto {
                 -countryOfResidence
@@ -104,28 +106,22 @@ title PSC Filing API: Target Data Model Class Structure
                 -residentialAddressSameAsCorrespondenceAddress: Boolean
             }
 
-           note "This models an individual PSC" as Note2
-             Note2 ... PscIndividualDto
+/'           note "This models an individual PSC" as Note2
+             Note2 .. PscIndividualDto'/
 
-            class PscIdentifiedDto {
+            class PscWithIdentificationDto {
                 -identification:IdentificationDto
             }
            note "This models the RLE (corporate) and the \nORP (legal) types of PSC" as Note1
-                Note1 ... PscIdentifiedDto
-/'            together {
-                class AddressDto
-                class Date3TupleDto
-                class IdentificationDto
-                class NameElementsDto
-            }'/            
+                Note1 .. PscWithIdentificationDto
 
-            PscIndividualDto::dateOfBirth o-- Date3TupleDto
-            PscDto::address o-- AddressDto
-            PscIndividualDto::residentialAddress o-- AddressDto
-            PscDto <|-- PscIdentifiedDto
-            PscIdentifiedDto::identification o-- IdentificationDto
             PscDto <|-- PscIndividualDto
+            PscDto <|-- PscWithIdentificationDto
             PscIndividualDto::nameElements o-- NameElementsDto
+            PscWithIdentificationDto o-- IdentificationDto
+            AddressDto -o PscDto::address
+            PscIndividualDto::residentialAddress o- AddressDto
+            Date3TupleDto -o PscIndividualDto::dateOfBirth
         }
     }
 

--- a/docs/Target Data Model of PSC Classes.puml
+++ b/docs/Target Data Model of PSC Classes.puml
@@ -2,7 +2,7 @@
 'https://plantuml.com/class-diagram
 'ortho
 skinparam linetype poly
-skinparam nodesep 60 /' horizontal separator '/
+skinparam nodesep 50 /' horizontal separator '/
 skinparam ranksep 50 /' vertical separator '/
 skinparam titleBorderRoundCorner 15
 skinparam titleBorderThickness 1
@@ -43,20 +43,36 @@ title PSC Filing API: Target Data Model Class Structure
 
             class IdentificationDto {
                 -countryRegistered
-                -legalAuthority
-                -legalForm
                 -placeRegistered
                 -registrationNumber
+                -legalAuthority
+               -legalForm
             }
 
-            class NamesElementDto {
+            class NameElementsDto {
                 -forename
                 -otherForenames
                 -surname
                 -title
             }
+            
+            class PscStatementDto {
+                -referenceEtag
+                -referenceStatementId
+                -restrictionsNoticeWithdrawlReason
+                -statementActionDate: LocalDate
+                -statementType []
+            }
 
-            abstract class PscFilingDto {
+          note left of PscStatementDto::referenceStatementId
+                Required for PSC09
+           end note
+
+          note left of PscStatementDto::statementType
+                See public spec for full list
+           end note            
+
+            abstract class PscDto {
                 -address: AddressDto
                 -addressSameAsRegisteredOfficeAddress: Boolean
                 -ceasedOn: LocalDate
@@ -69,73 +85,47 @@ title PSC Filing API: Target Data Model Class Structure
                 -registerEntryDate: LocalDate
             }
 
-            class PscFilingIndividualDto {
+           note left of PscDto::naturesOfControl
+                See public spec for full list
+            end note
+
+/'            together {
+                class PscIndividualDto
+                class PscFilingCorporateDto
+                class PscFilingRleDto
+            }'/
+
+            class PscIndividualDto {
                 -countryOfResidence
                 -dateOfBirth: Date3TupleDto
-                -nameElements: NamesElementDto
+                -nameElements: NameElementsDto
                 -nationality
                 -residentialAddress: AddressDto
                 -residentialAddressSameAsCorrespondenceAddress: Boolean
             }
 
-            class PscFilingOrpDto {
-                -identification: IdentificationDto
+           note "This models an individual PSC" as Note2
+             Note2 ... PscIndividualDto
+
+            class PscIdentifiedDto {
+                -identification:IdentificationDto
             }
-
-            class PscFilingRleDto {
-                -identification: IdentificationDto
-            }
-
-            class LegalIdentificationDto {
-                legalAuthority
-                legalForm
-            }
-
-/'           note right of PscFilingRleDto::identification
-                legalAuthority
-                and/or legalForm
-            end note'/
-
-            class StatementDto {
-                -referenceEtag
-                -referenceStatementId
-                -restrictionsNoticeWithdrawlReason
-                -statementActionDate: LocalDate
-                -statementType []
-            }
-
-          note left of StatementDto::referenceStatementId
-                required for PSC09
-           end note
-
-          note left of StatementDto::statementType
-                see public spec for full list
-           end note
-
-            together {
-                class PscFilingIndividualDto
-                class PscFilingOrpDto
-                class PscFilingRleDto
-            }
-
-            together {
+           note "This models the RLE (corporate) and the \nORP (legal) types of PSC" as Note1
+                Note1 ... PscIdentifiedDto
+/'            together {
                 class AddressDto
                 class Date3TupleDto
                 class IdentificationDto
-                class NamesElementDto
-            }
+                class NameElementsDto
+            }'/            
 
-            PscFilingIndividualDto - Date3TupleDto
-
-            PscFilingDto::address o-l- AddressDto
-            PscFilingIndividualDto::residential_address o-- AddressDto
-            PscFilingIndividualDto o-u- Date3TupleDto
-            PscFilingRleDto o-u- LegalIdentificationDto
-            PscFilingOrpDto o-u- IdentificationDto
-            PscFilingIndividualDto o-u- NamesElementDto
-            PscFilingDto <|-- PscFilingIndividualDto
-            PscFilingDto <|-- PscFilingOrpDto
-            PscFilingDto <|-- PscFilingRleDto
+            PscIndividualDto::dateOfBirth o-- Date3TupleDto
+            PscDto::address o-- AddressDto
+            PscIndividualDto::residentialAddress o-- AddressDto
+            PscDto <|-- PscIdentifiedDto
+            PscIdentifiedDto::identification o-- IdentificationDto
+            PscDto <|-- PscIndividualDto
+            PscIndividualDto::nameElements o-- NameElementsDto
         }
     }
 

--- a/docs/Target Data Model of PSC Classes.puml
+++ b/docs/Target Data Model of PSC Classes.puml
@@ -1,0 +1,142 @@
+@startuml
+'https://plantuml.com/class-diagram
+'ortho
+skinparam linetype poly
+skinparam nodesep 60 /' horizontal separator '/
+skinparam ranksep 50 /' vertical separator '/
+skinparam titleBorderRoundCorner 15
+skinparam titleBorderThickness 1
+skinparam titleBorderColor black
+skinparam titleBackgroundColor PaleTurquoise
+skinparam groupInheritance 1
+scale 1
+hide empty members
+'hide circle'
+skinparam titleFontSize 16
+
+title PSC Filing API: Target Data Model Class Structure
+
+    package "model" {
+
+        package "dto" {
+
+            class AddressDto {
+                -addressLine1
+                -addressLine2
+                -careOf
+                -country
+                -poBox
+                -postalCode
+                -premises
+                -region
+            }
+
+            class Date3TupleDto {
+                -day:int
+                -month:int
+                -year:int
+            }
+            note right of Date3TupleDto
+               day is null
+               for partial DOB
+            end note
+
+            class IdentificationDto {
+                -countryRegistered
+                -legalAuthority
+                -legalForm
+                -placeRegistered
+                -registrationNumber
+            }
+
+            class NamesElementDto {
+                -forename
+                -otherForenames
+                -surname
+                -title
+            }
+
+            abstract class PscFilingDto {
+                -address: AddressDto
+                -addressSameAsRegisteredOfficeAddress: Boolean
+                -ceasedOn: LocalDate
+                -name
+                -naturesOfControl[1..*]
+                -notifiedOn: LocalDate
+                -referenceEtag
+                -referencePscId
+                -referencePscListEtag
+                -registerEntryDate: LocalDate
+            }
+
+            class PscFilingIndividualDto {
+                -countryOfResidence
+                -dateOfBirth: Date3TupleDto
+                -nameElements: NamesElementDto
+                -nationality
+                -residentialAddress: AddressDto
+                -residentialAddressSameAsCorrespondenceAddress: Boolean
+            }
+
+            class PscFilingOrpDto {
+                -identification: IdentificationDto
+            }
+
+            class PscFilingRleDto {
+                -identification: IdentificationDto
+            }
+
+            class LegalIdentificationDto {
+                legalAuthority
+                legalForm
+            }
+
+/'           note right of PscFilingRleDto::identification
+                legalAuthority
+                and/or legalForm
+            end note'/
+
+            class StatementDto {
+                -referenceEtag
+                -referenceStatementId
+                -restrictionsNoticeWithdrawlReason
+                -statementActionDate: LocalDate
+                -statementType []
+            }
+
+          note left of StatementDto::referenceStatementId
+                required for PSC09
+           end note
+
+          note left of StatementDto::statementType
+                see public spec for full list
+           end note
+
+            together {
+                class PscFilingIndividualDto
+                class PscFilingOrpDto
+                class PscFilingRleDto
+            }
+
+            together {
+                class AddressDto
+                class Date3TupleDto
+                class IdentificationDto
+                class NamesElementDto
+            }
+
+            PscFilingIndividualDto - Date3TupleDto
+
+            PscFilingDto::address o-l- AddressDto
+            PscFilingIndividualDto::residential_address o-- AddressDto
+            PscFilingIndividualDto o-u- Date3TupleDto
+            PscFilingRleDto o-u- LegalIdentificationDto
+            PscFilingOrpDto o-u- IdentificationDto
+            PscFilingIndividualDto o-u- NamesElementDto
+            PscFilingDto <|-- PscFilingIndividualDto
+            PscFilingDto <|-- PscFilingOrpDto
+            PscFilingDto <|-- PscFilingRleDto
+        }
+    }
+
+@enduml


### PR DESCRIPTION
Add new class data model diagrams for Target and Internal data.

Please install:

1. GraphViz via HomeBrew
     and the following plugins in IntelliJ:
1.  PlantUML Integration
1.  PlantUML Diagram Generator

