### PR TITLE
Defect fix - Add registerEntryDate to builder(Filing) constructor

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/model/entity/PscIndividualFiling.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/model/entity/PscIndividualFiling.java
@@ -222,6 +222,7 @@ public class PscIndividualFiling implements PscCommunal {
                     .countryOfResidence(other.getCountryOfResidence())
                     .createdAt(other.getCreatedAt())
                     .dateOfBirth(other.getDateOfBirth())
+                    .registerEntryDate(other.getRegisterEntryDate())
                     .etag(other.getEtag())
                     .kind(other.getKind())
                     .links(other.getLinks())


### PR DESCRIPTION
when `PscIndividualFiling` was being resaved with the links section, the `register_entry_date` attribute wasn't being included.

PSC-59