### PR TITLE
Remove PSC type from the links for resource and validation_status

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/PscFilingControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/PscFilingControllerImpl.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import org.apache.commons.lang3.StringUtils;
 import org.bson.types.ObjectId;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -155,13 +156,16 @@ public class PscFilingControllerImpl implements PscFilingController {
 
     private Links buildLinks(final PscIndividualFiling savedFiling, final HttpServletRequest request) {
         final var objectId = new ObjectId(Objects.requireNonNull(savedFiling.getId()));
-        final var uriBuilder = UriComponentsBuilder.fromUriString(request.getRequestURI())
-                .pathSegment(objectId.toHexString());
-        final var selfUri = uriBuilder.build().toUri();
-        final var privateUriBuilder =
-                UriComponentsBuilder.fromUriString(PREFIX_PRIVATE + "/" + request.getRequestURI())
-                        .pathSegment(objectId.toHexString());
-        final var validateUri = privateUriBuilder.pathSegment(VALIDATION_STATUS)
+        final var selfUri = UriComponentsBuilder
+                .fromUriString(request.getRequestURI())
+                .pathSegment(objectId.toHexString())
+                .build().toUri();
+
+        final var validateUri = UriComponentsBuilder
+                .fromUriString(PREFIX_PRIVATE + "/" + request.getRequestURI()
+                .replace(StringUtils.join("/", PscTypeConstants.INDIVIDUAL.getValue()), ""))
+                .pathSegment(objectId.toHexString())
+                .pathSegment(VALIDATION_STATUS)
                 .build().toUri();
 
         return new Links(selfUri, validateUri);

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/PscFilingControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/PscFilingControllerImpl.java
@@ -154,10 +154,12 @@ public class PscFilingControllerImpl implements PscFilingController {
         return links;
     }
 
+    // TODO Refactor this to handle PSC types other than Individual, in both the arguments and the path build
     private Links buildLinks(final PscIndividualFiling savedFiling, final HttpServletRequest request) {
         final var objectId = new ObjectId(Objects.requireNonNull(savedFiling.getId()));
         final var selfUri = UriComponentsBuilder
-                .fromUriString(request.getRequestURI())
+                .fromUriString(request.getRequestURI()
+                .replace(StringUtils.join("/", PscTypeConstants.INDIVIDUAL.getValue()), ""))
                 .pathSegment(objectId.toHexString())
                 .build().toUri();
 

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscFilingControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscFilingControllerImplIT.java
@@ -101,7 +101,7 @@ class PscFilingControllerImplIT {
                 .build();
         final var locationUri = UriComponentsBuilder.fromPath("/")
                 .pathSegment("transactions", TRANS_ID,
-                        "persons-with-significant-control/individual", FILING_ID)
+                        "persons-with-significant-control", FILING_ID)
                 .build();
 
         transaction.setId(TRANS_ID);

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscFilingControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscFilingControllerImplTest.java
@@ -55,6 +55,9 @@ class PscFilingControllerImplTest {
     public static final String FILING_ID = "6332aa6ed28ad2333c3a520a";
     private static final URI REQUEST_URI = URI.create("/transactions/"
             + TRANS_ID
+            + "/persons-with-significant-control/");
+    private static final URI REQUEST_URI_WITH_PSC_TYPE = URI.create("/transactions/"
+            + TRANS_ID
             + "/persons-with-significant-control/"
             + PSC_TYPE.getValue());
     private static final Instant FIRST_INSTANT = Instant.parse("2022-10-15T09:44:08.108Z");
@@ -97,7 +100,7 @@ class PscFilingControllerImplTest {
                 .referenceEtag("etag")
                 .ceasedOn(LocalDate.parse("2022-09-13"))
                 .build();
-        final var builder = UriComponentsBuilder.fromUri(REQUEST_URI);
+        final var builder = UriComponentsBuilder.fromUri(REQUEST_URI_WITH_PSC_TYPE);
         final var privateBuilder =
                 UriComponentsBuilder.fromUri(URI.create(PREFIX_PRIVATE + "/" + REQUEST_URI));
         links = new Links(builder.pathSegment(FILING_ID)
@@ -126,7 +129,7 @@ class PscFilingControllerImplTest {
         when(pscFilingService.save(withLinks, TRANS_ID)).thenReturn(withLinks);
         when(pscDetailsService.getPscDetails(transaction, PSC_ID, PSC_TYPE,
                 PASSTHROUGH_HEADER)).thenReturn(pscDetails);
-        when(request.getRequestURI()).thenReturn(REQUEST_URI.toString());
+        when(request.getRequestURI()).thenReturn(REQUEST_URI_WITH_PSC_TYPE.toString());
         when(clock.instant()).thenReturn(FIRST_INSTANT);
 
         final var response = testController.createFiling(TRANS_ID, PSC_TYPE, dto,
@@ -158,9 +161,9 @@ class PscFilingControllerImplTest {
     private Map<String, Resource> createResources() {
         final Map<String, Resource> resourceMap = new HashMap<>();
         final var resource = new Resource();
-        final var self = REQUEST_URI + "/" + FILING_ID;
+        final var self = REQUEST_URI_WITH_PSC_TYPE + "/" + FILING_ID;
         final var linksMap = Map.of("resource", self, VALIDATION_STATUS,
-                PREFIX_PRIVATE + REQUEST_URI + "/" + FILING_ID + "/" + VALIDATION_STATUS);
+                PREFIX_PRIVATE + REQUEST_URI_WITH_PSC_TYPE + "/" + FILING_ID + "/" + VALIDATION_STATUS);
 
         resource.setKind("psc-filing");
         resource.setLinks(linksMap);

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscFilingControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscFilingControllerImplTest.java
@@ -56,10 +56,6 @@ class PscFilingControllerImplTest {
     private static final URI REQUEST_URI = URI.create("/transactions/"
             + TRANS_ID
             + "/persons-with-significant-control/");
-    private static final URI REQUEST_URI_WITH_PSC_TYPE = URI.create("/transactions/"
-            + TRANS_ID
-            + "/persons-with-significant-control/"
-            + PSC_TYPE.getValue());
     private static final Instant FIRST_INSTANT = Instant.parse("2022-10-15T09:44:08.108Z");
 
     private PscFilingController testController;
@@ -100,7 +96,7 @@ class PscFilingControllerImplTest {
                 .referenceEtag("etag")
                 .ceasedOn(LocalDate.parse("2022-09-13"))
                 .build();
-        final var builder = UriComponentsBuilder.fromUri(REQUEST_URI_WITH_PSC_TYPE);
+        final var builder = UriComponentsBuilder.fromUri(REQUEST_URI);
         final var privateBuilder =
                 UriComponentsBuilder.fromUri(URI.create(PREFIX_PRIVATE + "/" + REQUEST_URI));
         links = new Links(builder.pathSegment(FILING_ID)
@@ -129,7 +125,7 @@ class PscFilingControllerImplTest {
         when(pscFilingService.save(withLinks, TRANS_ID)).thenReturn(withLinks);
         when(pscDetailsService.getPscDetails(transaction, PSC_ID, PSC_TYPE,
                 PASSTHROUGH_HEADER)).thenReturn(pscDetails);
-        when(request.getRequestURI()).thenReturn(REQUEST_URI_WITH_PSC_TYPE.toString());
+        when(request.getRequestURI()).thenReturn(REQUEST_URI.toString());
         when(clock.instant()).thenReturn(FIRST_INSTANT);
 
         final var response = testController.createFiling(TRANS_ID, PSC_TYPE, dto,
@@ -161,9 +157,9 @@ class PscFilingControllerImplTest {
     private Map<String, Resource> createResources() {
         final Map<String, Resource> resourceMap = new HashMap<>();
         final var resource = new Resource();
-        final var self = REQUEST_URI_WITH_PSC_TYPE + "/" + FILING_ID;
+        final var self = REQUEST_URI + "/" + FILING_ID;
         final var linksMap = Map.of("resource", self, VALIDATION_STATUS,
-                PREFIX_PRIVATE + REQUEST_URI_WITH_PSC_TYPE + "/" + FILING_ID + "/" + VALIDATION_STATUS);
+                PREFIX_PRIVATE + REQUEST_URI + "/" + FILING_ID + "/" + VALIDATION_STATUS);
 
         resource.setKind("psc-filing");
         resource.setLinks(linksMap);


### PR DESCRIPTION
Transaction resource now:
```
"resources" : {
            "/transactions/172423-265216-714864/persons-with-significant-control/individual/63a0dbe19a752f422f891c93" : {
                "kind" : "psc-filing",
                "links" : {
                    "resource" : "/transactions/172423-265216-714864/persons-with-significant-control/63a0dbe19a752f422f891c93",
                    "validation_status" : "/private/transactions/172423-265216-714864/persons-with-significant-control/63a0dbe19a752f422f891c93/validation_status"
                },
                "updated_at" : ISODate("2022-12-19T21:47:13.000Z")
            }
        },
```

PSC Filing Resource links now:
```
    "links" : {
        "self" : "/transactions/172423-265216-714864/persons-with-significant-control/63a0dbe19a752f422f891c93",
        "validation_status" : "/private/transactions/172423-265216-714864/persons-with-significant-control/63a0dbe19a752f422f891c93/validation_status"
    },
```

The transaction will now close successfully, and the Filing Resource handler will pick up the filing
PSC-85