### PR TITLE
Change self link back to include PSC type

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/FilingDataController.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/FilingDataController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
 import uk.gov.companieshouse.pscfiling.api.exception.NotImplementedException;
+import uk.gov.companieshouse.pscfiling.api.model.PscTypeConstants;
 
 public interface FilingDataController {
 
@@ -19,6 +20,7 @@ public interface FilingDataController {
      */
     @GetMapping
     default List<FilingApi> getFilingsData(@PathVariable("transId") String transId,
+                                           @PathVariable("pscType") PscTypeConstants pscType,
                                            @PathVariable("filingResource") String filingResource, HttpServletRequest request){
         throw new NotImplementedException();
     }

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/FilingDataControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/FilingDataControllerImpl.java
@@ -8,13 +8,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
 import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.pscfiling.api.model.PscTypeConstants;
 import uk.gov.companieshouse.pscfiling.api.service.FilingDataService;
 import uk.gov.companieshouse.pscfiling.api.service.TransactionService;
 import uk.gov.companieshouse.pscfiling.api.utils.LogHelper;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
 @RestController
-@RequestMapping("/private/transactions/{transId}/persons-with-significant-control")
+@RequestMapping("/private/transactions/{transId}/persons-with-significant-control/{pscType}")
 public class FilingDataControllerImpl implements FilingDataController {
     private final FilingDataService filingDataService;
     private final TransactionService transactionService;
@@ -40,6 +41,7 @@ public class FilingDataControllerImpl implements FilingDataController {
     @Override
     @GetMapping(value = "/{filingResourceId}/filings", produces = {"application/json"})
     public List<FilingApi> getFilingsData(@PathVariable("transId") final String transId,
+            @PathVariable("pscType") final PscTypeConstants pscType,
             @PathVariable("filingResourceId") final String filingResource,
             final HttpServletRequest request) {
         final var logMap = LogHelper.createLogMap(transId, filingResource);

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/PscFilingControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/PscFilingControllerImpl.java
@@ -171,8 +171,7 @@ public class PscFilingControllerImpl implements PscFilingController {
     private Links buildLinks(final PscIndividualFiling savedFiling, final HttpServletRequest request) {
         final var objectId = new ObjectId(Objects.requireNonNull(savedFiling.getId()));
         final var selfUri = UriComponentsBuilder
-                .fromUriString(request.getRequestURI()
-                .replace(StringUtils.join("/", PscTypeConstants.INDIVIDUAL.getValue()), ""))
+                .fromUriString(request.getRequestURI())
                 .pathSegment(objectId.toHexString())
                 .build().toUri();
 

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/FilingDataControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/FilingDataControllerImplIT.java
@@ -70,7 +70,7 @@ class FilingDataControllerImplIT {
         when(transactionService.getTransaction(TRANS_ID, PASSTHROUGH_HEADER)).thenReturn(transaction);
         when(filingDataService.generatePscFiling(FILING_ID, transaction, PASSTHROUGH_HEADER)).thenReturn(filingApi);
 
-        mockMvc.perform(get("/private/transactions/{id}/persons-with-significant-control/{filingId}/filings", TRANS_ID, FILING_ID)
+        mockMvc.perform(get("/private/transactions/{id}/persons-with-significant-control/individual/{filingId}/filings", TRANS_ID, FILING_ID)
             .headers(httpHeaders))
             .andDo(print())
             .andExpect(status().isOk())
@@ -87,7 +87,7 @@ class FilingDataControllerImplIT {
         when(transactionService.getTransaction(TRANS_ID, PASSTHROUGH_HEADER)).thenReturn(
                 transaction);
 
-        mockMvc.perform(get("/private/transactions/{id}/persons-with-significant-control/{filingId}/filings", TRANS_ID, FILING_ID)
+        mockMvc.perform(get("/private/transactions/{id}/persons-with-significant-control/individual/{filingId}/filings", TRANS_ID, FILING_ID)
                 .headers(httpHeaders))
                 .andDo(print())
                 .andExpect(status().isNotFound())

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/FilingDataControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/FilingDataControllerImplTest.java
@@ -16,6 +16,7 @@ import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.pscfiling.api.exception.FilingResourceNotFoundException;
+import uk.gov.companieshouse.pscfiling.api.model.PscTypeConstants;
 import uk.gov.companieshouse.pscfiling.api.model.entity.PscIndividualFiling;
 import uk.gov.companieshouse.pscfiling.api.service.FilingDataService;
 import uk.gov.companieshouse.pscfiling.api.service.TransactionService;
@@ -26,6 +27,7 @@ class FilingDataControllerImplTest {
 
     public static final String TRANS_ID = "117524-754816-491724";
     public static final String FILING_ID = "6332aa6ed28ad2333c3a520a";
+    public static final PscTypeConstants PSC_TYPE = PscTypeConstants.INDIVIDUAL;
     private static final String PASSTHROUGH_HEADER = "passthrough";
     private Transaction transaction;
 
@@ -60,7 +62,7 @@ class FilingDataControllerImplTest {
         when(filingDataService.generatePscFiling(FILING_ID, transaction, PASSTHROUGH_HEADER)).thenReturn(filingApi);
         when(transactionService.getTransaction(TRANS_ID, PASSTHROUGH_HEADER)).thenReturn(transaction);
 
-        final var filingsList= testController.getFilingsData(TRANS_ID, FILING_ID, request);
+        final var filingsList= testController.getFilingsData(TRANS_ID, PSC_TYPE, FILING_ID, request);
 
         assertThat(filingsList, Matchers.contains(filingApi));
     }
@@ -72,7 +74,7 @@ class FilingDataControllerImplTest {
         when(filingDataService.generatePscFiling(FILING_ID, transaction, PASSTHROUGH_HEADER)).thenThrow(new FilingResourceNotFoundException("Test Resource not found"));
 
         final var exception = assertThrows(FilingResourceNotFoundException.class,
-                () -> testController.getFilingsData(TRANS_ID, FILING_ID, request));
+                () -> testController.getFilingsData(TRANS_ID, PSC_TYPE, FILING_ID, request));
         assertThat(exception.getMessage(), is("Test Resource not found"));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/FilingDataControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/FilingDataControllerTest.java
@@ -6,6 +6,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import uk.gov.companieshouse.pscfiling.api.exception.NotImplementedException;
+import uk.gov.companieshouse.pscfiling.api.model.PscTypeConstants;
 
 class FilingDataControllerTest {
 
@@ -18,6 +19,6 @@ class FilingDataControllerTest {
         var testController = new FilingDataController(){};
 
         assertThrows(NotImplementedException.class,
-            () -> testController.getFilingsData("trans-id", "filing-id", request));
+            () -> testController.getFilingsData("trans-id", PscTypeConstants.INDIVIDUAL, "filing-id", request));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscFilingControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscFilingControllerImplIT.java
@@ -113,7 +113,7 @@ class PscFilingControllerImplIT {
                 .build();
         final var locationUri = UriComponentsBuilder.fromPath("/")
                 .pathSegment("transactions", TRANS_ID,
-                        "persons-with-significant-control", FILING_ID)
+                        "persons-with-significant-control/individual", FILING_ID)
                 .build();
 
         transaction.setId(TRANS_ID);


### PR DESCRIPTION
- amend FilingData path  to accommodate PSC type
- should now allow the GET endpoint and `filings` endpoint to resolve