### PR TITLE
Adding Filing description for storing in filings data of transaction

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/model/FilingKind.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/model/FilingKind.java
@@ -5,16 +5,22 @@ import java.util.Optional;
 
 public enum FilingKind {
 
-    PSC_CESSATION("psc-filing#cessation");
+    PSC_CESSATION("psc-filing#cessation",  "Notice of ceasing to be a Person of Significant Control");
 
-    FilingKind(final String value) {
+    FilingKind(final String value, String description) {
         this.value = value;
+        this.description = description;
     }
 
     private final String value;
+    private final String description;
 
     public String getValue() {
         return value;
+    }
+
+    public String getDescription() {
+        return description;
     }
 
     public static Optional<FilingKind> nameOf(final String value) {

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/service/FilingDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/service/FilingDataServiceImpl.java
@@ -38,6 +38,7 @@ public class FilingDataServiceImpl implements FilingDataService {
     public FilingApi generatePscFiling(String filingId, Transaction transaction, String passthroughHeader) {
         var filing = new FilingApi();
         filing.setKind(FilingKind.PSC_CESSATION.getValue()); // TODO: handling other kinds to come later
+        filing.setDescription(FilingKind.PSC_CESSATION.getDescription());
 
         return populateFilingData(filing, filingId, transaction, passthroughHeader);
     }

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/model/FilingKindTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/model/FilingKindTest.java
@@ -20,6 +20,11 @@ class FilingKindTest {
     }
 
     @Test
+    void getDescription() {
+        assertThat(FilingKind.PSC_CESSATION.getDescription(), is ("Notice of ceasing to be a Person of Significant Control"));
+    }
+
+    @Test
     void nameOfWhenFound() {
         assertThat(FilingKind.nameOf("psc-filing#cessation"), is(Optional.of(FilingKind.PSC_CESSATION)));
     }


### PR DESCRIPTION
This is NOT for merging in yet.
- I've come up with a description for the Filing Type in the table in the email.  The story doesn't detail this, but this is where it would need to be added.
- in the `transactions` collection there is a `description_identifier`, but I don't think it's required.  I don't see it being used in any email services.  However, we could add something like the second snippet below:
```
        "filings" : {
            "090299-826316-727536-1" : {
                "company_number" : "00006400",
                "description" : "Notice of ceasing to be a Person of Significant Control",
                "description_identifier" : "",
```
```
                "description" : "Change of registered office address",
                "description_identifier" : "change-registered-office-address",
```
- In Docker I've enabled all the relevant services, including `notification-sender` which isn't actually present in `docker-chs-development`, but even with that running I don't receive an email.  Logs look good though:
<img width="1529" alt="Screenshot 2023-01-03 at 2 54 23 pm" src="https://user-images.githubusercontent.com/2736331/210381763-3305d4cc-fa95-40df-be03-6fa4f07388f2.png">

PSC-50