### PR TITLE
Validation status endpoint fix in database - remove word 'private'

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/PscFilingControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/PscFilingControllerImpl.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.pscfiling.api.controller;
 
-import static uk.gov.companieshouse.pscfiling.api.model.entity.Links.PREFIX_PRIVATE;
-
 import java.time.Clock;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -167,7 +165,7 @@ public class PscFilingControllerImpl implements PscFilingController {
                 .build().toUri();
 
         final var validateUri = UriComponentsBuilder
-                .fromUriString(PREFIX_PRIVATE + "/" + request.getRequestURI()
+                .fromUriString(request.getRequestURI()
                 .replace(StringUtils.join("/", PscTypeConstants.INDIVIDUAL.getValue()), ""))
                 .pathSegment(objectId.toHexString())
                 .pathSegment(VALIDATION_STATUS)

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscFilingControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscFilingControllerImplTest.java
@@ -108,12 +108,9 @@ class PscFilingControllerImplTest {
                 .ceasedOn(LocalDate.parse("2022-09-13"))
                 .build();
         final var builder = UriComponentsBuilder.fromUri(REQUEST_URI);
-        final var privateBuilder =
-                UriComponentsBuilder.fromUri(URI.create(PREFIX_PRIVATE + "/" + REQUEST_URI));
         links = new Links(builder.pathSegment(FILING_ID)
-                .build().toUri(),
-                privateBuilder.pathSegment(FILING_ID).pathSegment("validation_status")
-                        .build().toUri());
+                .build().toUri(), builder.pathSegment("validation_status")
+                .build().toUri());
         resourceMap = createResources();
         validationErrors = new ArrayList<>();
         bindingErrorCodes = new String[]{"code1", "code2.name", "code3"};


### PR DESCRIPTION
PSC-119
Collections transaction and psc_submissions in the transactions_pscs database have the word 'private' removed from the links entry. All tests are passing and request working as expected in Postman.