### PR TITLE
Validation to match the reference_etag supplied

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/config/ValidatorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/config/ValidatorConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import uk.gov.companieshouse.pscfiling.api.model.PscTypeConstants;
 import uk.gov.companieshouse.pscfiling.api.validator.FilingForPscTypeValid;
 import uk.gov.companieshouse.pscfiling.api.validator.FilingForPscTypeValidChain;
+import uk.gov.companieshouse.pscfiling.api.validator.PscEtagValidator;
 import uk.gov.companieshouse.pscfiling.api.validator.PscExistsValidator;
 
 @Configuration
@@ -12,7 +13,8 @@ public class ValidatorConfig {
 
     @Bean
     public FilingForPscTypeValid filingForIndividualValid(
-            final PscExistsValidator pscExistsValidator) {
+            final PscExistsValidator pscExistsValidator, PscEtagValidator pscEtagValidator) {
+        pscExistsValidator.setNext(pscEtagValidator);
         return new FilingForPscTypeValidChain(PscTypeConstants.INDIVIDUAL, pscExistsValidator);
     }
 

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/validator/PscEtagValidator.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/validator/PscEtagValidator.java
@@ -4,12 +4,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.FieldError;
 import uk.gov.companieshouse.api.model.psc.PscApi;
-import uk.gov.companieshouse.pscfiling.api.exception.FilingResourceNotFoundException;
-import uk.gov.companieshouse.pscfiling.api.exception.PscServiceException;
 import uk.gov.companieshouse.pscfiling.api.service.PscDetailsService;
 
 /**
- * A previous validator must have checked that the PSC exists
+ * A previous validator must have checked that the PSC exists.
  */
 @Component
 public class PscEtagValidator extends BaseFilingValidator implements FilingValid {
@@ -23,8 +21,7 @@ public class PscEtagValidator extends BaseFilingValidator implements FilingValid
     @Override
     public void validate(final FilingValidationContext validationContext) {
 
-        final PscApi pscDetails;
-        pscDetails = pscDetailsService.getPscDetails(validationContext.getTransaction(),
+        final PscApi pscDetails = pscDetailsService.getPscDetails(validationContext.getTransaction(),
                 validationContext.getDto().getReferencePscId(), validationContext.getPscType(),
                 validationContext.getPassthroughHeader());
 

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/validator/PscEtagValidator.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/validator/PscEtagValidator.java
@@ -1,0 +1,40 @@
+package uk.gov.companieshouse.pscfiling.api.validator;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.FieldError;
+import uk.gov.companieshouse.api.model.psc.PscApi;
+import uk.gov.companieshouse.pscfiling.api.exception.FilingResourceNotFoundException;
+import uk.gov.companieshouse.pscfiling.api.exception.PscServiceException;
+import uk.gov.companieshouse.pscfiling.api.service.PscDetailsService;
+
+/**
+ * A previous validator must have checked that the PSC exists
+ */
+@Component
+public class PscEtagValidator extends BaseFilingValidator implements FilingValid {
+
+    private PscDetailsService pscDetailsService;
+
+    public PscEtagValidator(PscDetailsService pscDetailsService) {
+        this.pscDetailsService = pscDetailsService;
+    }
+
+    @Override
+    public void validate(final FilingValidationContext validationContext) {
+
+        final PscApi pscDetails;
+        pscDetails = pscDetailsService.getPscDetails(validationContext.getTransaction(),
+                validationContext.getDto().getReferencePscId(), validationContext.getPscType(),
+                validationContext.getPassthroughHeader());
+
+        if (!StringUtils.equals(pscDetails.getEtag(), validationContext.getDto().getReferenceEtag())) {
+            validationContext.getErrors()
+                    .add(new FieldError("object", "reference_etag", validationContext.getDto().getReferenceEtag(),
+                            false, new String[]{null, "notMatch.reference_etag"}, null,
+                            "Etag for PSC does not match latest value"));
+        }
+
+        super.validate(validationContext);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/validator/PscExistsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/validator/PscExistsValidator.java
@@ -18,17 +18,17 @@ public class PscExistsValidator extends BaseFilingValidator implements FilingVal
     public void validate(final FilingValidationContext validationContext) {
 
         try {
-                pscDetailsService.getPscDetails(validationContext.getTransaction(), validationContext.getDto()
+            pscDetailsService.getPscDetails(validationContext.getTransaction(), validationContext.getDto()
                                 .getReferencePscId(), validationContext.getPscType(),
                         validationContext.getPassthroughHeader());
+            // Validation should not continue if PSC does not exist
+            super.validate(validationContext);
         }
         catch (FilingResourceNotFoundException e) {
             validationContext.getErrors().add(
                     new FieldError("object", "reference_psc_id", validationContext.getDto().getReferencePscId(), false,
                             new String[]{null, "notFound.reference_psc_id"}, null, "PSC with that reference ID was not found"));
         }
-
-        super.validate(validationContext);
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/config/ValidatorConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/config/ValidatorConfigTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.pscfiling.api.model.PscTypeConstants;
+import uk.gov.companieshouse.pscfiling.api.validator.PscEtagValidator;
 import uk.gov.companieshouse.pscfiling.api.validator.PscExistsValidator;
 
 @ExtendWith(MockitoExtension.class)
@@ -16,6 +17,8 @@ class ValidatorConfigTest {
     private ValidatorConfig testConfig;
     @Mock
     private PscExistsValidator pscExistsValidator;
+    @Mock
+    private PscEtagValidator pscEtagValidator;
 
 
     @BeforeEach
@@ -25,7 +28,7 @@ class ValidatorConfigTest {
 
     @Test
     void filingForIndividualValid() {
-        final var valid = testConfig.filingForIndividualValid(pscExistsValidator);
+        final var valid = testConfig.filingForIndividualValid(pscExistsValidator, pscEtagValidator);
 
         assertThat(valid.getPscType(), is(PscTypeConstants.INDIVIDUAL));
         assertThat(valid.getFirst(), is(pscExistsValidator));

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/validator/PscEtagValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/validator/PscEtagValidatorTest.java
@@ -1,0 +1,90 @@
+package uk.gov.companieshouse.pscfiling.api.validator;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.validation.FieldError;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.model.psc.PscApi;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.pscfiling.api.exception.FilingResourceNotFoundException;
+import uk.gov.companieshouse.pscfiling.api.model.PscTypeConstants;
+import uk.gov.companieshouse.pscfiling.api.model.dto.PscIndividualDto;
+import uk.gov.companieshouse.pscfiling.api.service.PscDetailsService;
+
+@ExtendWith(MockitoExtension.class)
+class PscEtagValidatorTest {
+
+    @Mock
+    private PscDetailsService pscDetailsService;
+    @Mock
+    private PscApi pscApi;
+    @Mock
+    private Transaction transaction;
+    @Mock
+    private PscIndividualDto dto;
+    @Mock
+    private ApiErrorResponseException errorResponseException;
+
+    PscEtagValidator testValidator;
+    private PscTypeConstants pscType;
+    private List<FieldError> errors;
+    private String passthroughHeader;
+
+    private static final String PSC_ID = "1kdaTltWeaP1EB70SSD9SLmiK5Y";
+    private static final String ETAG = "1234567";
+
+    @BeforeEach
+    void setUp() {
+
+        errors = new ArrayList<>();
+        pscType = PscTypeConstants.INDIVIDUAL;
+        passthroughHeader = "passthroughHeader";
+
+        testValidator = new PscEtagValidator(pscDetailsService);
+    }
+
+    @Test
+    void validateWhenEtagMatches() {
+
+        when(dto.getReferencePscId()).thenReturn(PSC_ID);
+        when(dto.getReferenceEtag()).thenReturn(ETAG);
+        when(pscDetailsService.getPscDetails(transaction, PSC_ID, pscType, passthroughHeader )).thenReturn(pscApi);
+        when(pscApi.getEtag()).thenReturn(ETAG);
+
+        testValidator.validate(
+                new FilingValidationContext(dto, errors, transaction, pscType, passthroughHeader));
+
+        assertThat(errors, is(empty()));
+    }
+
+    @Test
+    void validateWhenEtagDoesNotMatch() {
+
+        var fieldError = new FieldError("object", "reference_etag", ETAG, false,
+                new String[]{null, "notMatch.reference_etag"}, null,
+                "Etag for PSC does not match latest value");
+        when(dto.getReferencePscId()).thenReturn(PSC_ID);
+        when(dto.getReferenceEtag()).thenReturn(ETAG);
+        when(pscDetailsService.getPscDetails(transaction, PSC_ID, pscType, passthroughHeader )).thenReturn(pscApi);
+        when(pscApi.getEtag()).thenReturn("some other etag value");
+
+        testValidator.validate(
+                new FilingValidationContext(dto, errors, transaction, pscType, passthroughHeader));
+
+        assertThat(errors.stream().findFirst().orElseThrow(), equalTo(fieldError));
+        assertThat(errors, contains(fieldError));
+    }
+}
+


### PR DESCRIPTION
- Add `PscEtagValidator` to chain
- Amended `PscExistsValidator` so that validation stops if this fails because it makes no sense to carry on validating for a PSC that doesn't exist in CHS
- Etag validation error that will be returned:
```
    "errors": [
        {
            "error": "Etag for PSC does not match latest value",
            "error_values": {
                "rejected": "8cb9d4c9ba82059ff01ed638105bc41c1bc4db40b"
            },
            "location": "$.reference_etag",
            "location_type": "json-path",
            "type": "ch:validation"
        }
    ]
```

PSC-29