### PR TITLE
Add validation that ceased on date on or after notified on date

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/config/ValidatorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/config/ValidatorConfig.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.pscfiling.api.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import uk.gov.companieshouse.pscfiling.api.model.PscTypeConstants;
+import uk.gov.companieshouse.pscfiling.api.validator.CeasedOnDateValidator;
 import uk.gov.companieshouse.pscfiling.api.validator.FilingForPscTypeValid;
 import uk.gov.companieshouse.pscfiling.api.validator.FilingForPscTypeValidChain;
 import uk.gov.companieshouse.pscfiling.api.validator.PscExistsValidator;
@@ -12,7 +13,8 @@ public class ValidatorConfig {
 
     @Bean
     public FilingForPscTypeValid filingForIndividualValid(
-            final PscExistsValidator pscExistsValidator) {
+            final PscExistsValidator pscExistsValidator, CeasedOnDateValidator ceasedOnDateValidator) {
+        pscExistsValidator.setNext(ceasedOnDateValidator);
         return new FilingForPscTypeValidChain(PscTypeConstants.INDIVIDUAL, pscExistsValidator);
     }
 

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/validator/CeasedOnDateValidator.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/validator/CeasedOnDateValidator.java
@@ -1,0 +1,34 @@
+package uk.gov.companieshouse.pscfiling.api.validator;
+
+import org.springframework.stereotype.Component;
+import org.springframework.validation.FieldError;
+import uk.gov.companieshouse.api.model.psc.PscApi;
+import uk.gov.companieshouse.pscfiling.api.service.PscDetailsService;
+
+@Component
+public class CeasedOnDateValidator extends BaseFilingValidator implements FilingValid {
+
+    private PscDetailsService pscDetailsService;
+
+    public CeasedOnDateValidator(PscDetailsService pscDetailsService) {
+        this.pscDetailsService = pscDetailsService;
+    }
+
+    @Override
+    public void validate(final FilingValidationContext validationContext) {
+
+        final PscApi pscDetails = pscDetailsService.getPscDetails(validationContext.getTransaction(),
+                validationContext.getDto().getReferencePscId(), validationContext.getPscType(),
+                validationContext.getPassthroughHeader());
+
+        if (validationContext.getDto().getCeasedOn().compareTo(pscDetails.getNotifiedOn()) < 0) {
+            validationContext.getErrors()
+                    .add(new FieldError("object", "ceased_on", validationContext.getDto().getCeasedOn(), false,
+                            new String[]{null, "date.ceased_on"}, null,
+                            "Ceased on date is before the date the PSC was notified on"));
+        }
+
+        super.validate(validationContext);
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/config/ValidatorConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/config/ValidatorConfigTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.pscfiling.api.model.PscTypeConstants;
+import uk.gov.companieshouse.pscfiling.api.validator.CeasedOnDateValidator;
 import uk.gov.companieshouse.pscfiling.api.validator.PscExistsValidator;
 
 @ExtendWith(MockitoExtension.class)
@@ -16,6 +17,8 @@ class ValidatorConfigTest {
     private ValidatorConfig testConfig;
     @Mock
     private PscExistsValidator pscExistsValidator;
+    @Mock
+    private CeasedOnDateValidator ceasedOnDateValidator;
 
 
     @BeforeEach
@@ -25,7 +28,7 @@ class ValidatorConfigTest {
 
     @Test
     void filingForIndividualValid() {
-        final var valid = testConfig.filingForIndividualValid(pscExistsValidator);
+        final var valid = testConfig.filingForIndividualValid(pscExistsValidator, ceasedOnDateValidator);
 
         assertThat(valid.getPscType(), is(PscTypeConstants.INDIVIDUAL));
         assertThat(valid.getFirst(), is(pscExistsValidator));

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/validator/CeasedOnDateValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/validator/CeasedOnDateValidatorTest.java
@@ -1,0 +1,92 @@
+package uk.gov.companieshouse.pscfiling.api.validator;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.validation.FieldError;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.model.psc.PscApi;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.pscfiling.api.model.PscTypeConstants;
+import uk.gov.companieshouse.pscfiling.api.model.dto.PscIndividualDto;
+import uk.gov.companieshouse.pscfiling.api.service.PscDetailsService;
+@ExtendWith(MockitoExtension.class)
+class CeasedOnDateValidatorTest {
+    @Mock
+    private PscDetailsService pscDetailsService;
+    @Mock
+    private PscApi pscApi;
+    @Mock
+    private Transaction transaction;
+    @Mock
+    private PscIndividualDto dto;
+    @Mock
+    private ApiErrorResponseException errorResponseException;
+
+    CeasedOnDateValidator testValidator;
+    private PscTypeConstants pscType;
+    private List<FieldError> errors;
+    private String passthroughHeader;
+
+    private static final String PSC_ID = "1kdaTltWeaP1EB70SSD9SLmiK5Y";
+    private LocalDate date = LocalDate.of(2020, 5, 10);
+    private LocalDate dayAfterDate = LocalDate.of(2020, 5, 11);
+
+    @BeforeEach
+    void setUp() {
+        errors = new ArrayList<>();
+        pscType = PscTypeConstants.INDIVIDUAL;
+        passthroughHeader = "passthroughHeader";
+        when(pscDetailsService.getPscDetails(transaction, PSC_ID, pscType, passthroughHeader)).thenReturn(pscApi);
+        when(dto.getReferencePscId()).thenReturn(PSC_ID);
+
+        testValidator = new CeasedOnDateValidator(pscDetailsService);
+    }
+
+    @Test
+    void validateWhenCeasedOnAfterNotifiedOn() {
+        when(dto.getCeasedOn()).thenReturn(dayAfterDate);
+        when(pscApi.getNotifiedOn()).thenReturn(date);
+
+        testValidator.validate(new FilingValidationContext(dto, errors, transaction, pscType, passthroughHeader));
+
+        assertThat(errors, is(empty()));
+    }
+
+    @Test
+    void validateWhenCeasedOnSameAsNotifiedOn() {
+        when(dto.getCeasedOn()).thenReturn(date);
+        when(pscApi.getNotifiedOn()).thenReturn(date);
+
+        testValidator.validate(new FilingValidationContext(dto, errors, transaction, pscType, passthroughHeader));
+
+        assertThat(errors, is(empty()));
+    }
+
+    @Test
+    void validateWhenCeasedOnBeforeNotifiedOn() {
+        var fieldError = new FieldError("object", "ceased_on", date, false, new String[]{null, "date.ceased_on"},
+                null,"Ceased on date is before the date the PSC was notified on");
+        when(dto.getCeasedOn()).thenReturn(date);
+        when(pscApi.getNotifiedOn()).thenReturn(dayAfterDate);
+
+        testValidator.validate(new FilingValidationContext(dto, errors, transaction, pscType, passthroughHeader));
+
+        assertThat(errors.stream().findFirst().orElseThrow(), equalTo(fieldError));
+        assertThat(errors, contains(fieldError));
+    }
+
+}
+


### PR DESCRIPTION
- add `CeasedOnDateValidator` to chain
- Ceased on date validation error that will be returned:
```
    "errors": [
        {
            "error": "Ceased on date is before the date the PSC was notified on",
            "error_values": {
                "rejected": "2016-04-05"
            },
            "location": "$.ceased_on",
            "location_type": "json-path",
            "type": "ch:validation"
        }
    ]
```

PSC-28