### PR TITLE
Ceased on date validator was throwing NPE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,7 @@
                             <version>${mapstruct.version}</version>
                         </path>
                     </annotationProcessorPaths>
+                    <parameters>true</parameters>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/validator/CeasedOnDateValidator.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/validator/CeasedOnDateValidator.java
@@ -21,13 +21,12 @@ public class CeasedOnDateValidator extends BaseFilingValidator implements Filing
                 validationContext.getDto().getReferencePscId(), validationContext.getPscType(),
                 validationContext.getPassthroughHeader());
 
-        if (validationContext.getDto().getCeasedOn().compareTo(pscDetails.getNotifiedOn()) < 0) {
+        final var ceasedOn = validationContext.getDto().getCeasedOn();
+        if (ceasedOn != null && ceasedOn.isBefore(pscDetails.getNotifiedOn())) {
             validationContext.getErrors()
-                    .add(new FieldError("object", "ceased_on", validationContext.getDto().getCeasedOn(), false,
-                            new String[]{null, "date.ceased_on"}, null,
-                            "Ceased on date is before the date the PSC was notified on"));
+                    .add(new FieldError("object", "ceased_on", ceasedOn, false, new String[]{null, "date.ceased_on"},
+                            null, "Ceased on date is before the date the PSC was notified on"));
         }
-
         super.validate(validationContext);
     }
 


### PR DESCRIPTION
This occurs if ceased on date, not supplied in the Filing data.  This null check allows the chain of validation to complete, and then the Spring validation of the property in the model will re reported as before.

PSC-120