### PR TITLE
Specify the full path for Interceptors

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/config/InterceptorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/config/InterceptorConfig.java
@@ -14,7 +14,8 @@ import uk.gov.companieshouse.api.interceptor.TransactionInterceptor;
 @ComponentScan("uk.gov.companieshouse.api")
 public class InterceptorConfig implements WebMvcConfigurer {
 
-    static final String[] TRANSACTIONS_LIST = {"/transactions/**"};
+    static final String[] TRANSACTIONS_LIST = {
+        "/transactions/{transaction_id}/persons-with-significant-control/{pscType:(?:individual|corporate-entity|legal-person)}"};
     public static final String PSC_FILING_API = "psc-filing-api";
 
     private TokenPermissionsInterceptor tokenPermissionsInterceptor;

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/config/InterceptorConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/config/InterceptorConfigTest.java
@@ -55,7 +55,8 @@ class InterceptorConfigTest {
         inOrder.verify(interceptorRegistry).addInterceptor(any(TransactionInterceptor.class));
         inOrder.verify(interceptorRegistry).addInterceptor(any(OpenTransactionInterceptor.class));
         inOrder.verify(interceptorRegistry).addInterceptor(tokenPermissionsInterceptor);
-        verify(interceptorRegistration, times(3)).addPathPatterns("/transactions/**");
+        verify(interceptorRegistration, times(3))
+                .addPathPatterns("/transactions/{transaction_id}/persons-with-significant-control/{pscType:(?:individual|corporate-entity|legal-person)}");
     }
 
 


### PR DESCRIPTION
- this avoids a NPE in the Interceptors when they attempt to retrieve the `pathVariables`
- the controllers will handle the requests as before, and a 404 will be returned as before if the URL doesn't match

PSC-130