### PR TITLE
Remove validation from post

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/config/ValidatorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/config/ValidatorConfig.java
@@ -10,21 +10,24 @@ import uk.gov.companieshouse.pscfiling.api.validator.PscEtagValidator;
 import uk.gov.companieshouse.pscfiling.api.validator.PscExistsValidator;
 import uk.gov.companieshouse.pscfiling.api.validator.PscIsActiveValidator;
 import uk.gov.companieshouse.pscfiling.api.validator.PscRegisterEntryDateValidator;
+import uk.gov.companieshouse.pscfiling.api.validator.TerminationRequiredFieldsValidator;
 
 @Configuration
 public class ValidatorConfig {
 
     @Bean
-    public FilingForPscTypeValid filingForIndividualValid(final PscExistsValidator pscExistsValidator,
+    public FilingForPscTypeValid filingForIndividualValid(final TerminationRequiredFieldsValidator terminationRequiredFieldsValidator,
+                                                          final PscExistsValidator pscExistsValidator,
                                                           final PscEtagValidator pscEtagValidator,
                                                           final CeasedOnDateValidator ceasedOnDateValidator,
                                                           final PscRegisterEntryDateValidator pscRegisterEntryDateValidator,
                                                           final PscIsActiveValidator pscIsActiveValidator) {
+        terminationRequiredFieldsValidator.setNext(pscExistsValidator);
         pscExistsValidator.setNext(pscEtagValidator);
         pscEtagValidator.setNext(ceasedOnDateValidator);
         ceasedOnDateValidator.setNext(pscRegisterEntryDateValidator);
         pscRegisterEntryDateValidator.setNext(pscIsActiveValidator);
 
-        return new FilingForPscTypeValidChain(PscTypeConstants.INDIVIDUAL, pscExistsValidator);
+        return new FilingForPscTypeValidChain(PscTypeConstants.INDIVIDUAL, terminationRequiredFieldsValidator);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/PscIndividualFilingControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/PscIndividualFilingControllerImpl.java
@@ -31,11 +31,9 @@ import uk.gov.companieshouse.pscfiling.api.model.dto.PscDtoCommunal;
 import uk.gov.companieshouse.pscfiling.api.model.dto.PscIndividualDto;
 import uk.gov.companieshouse.pscfiling.api.model.entity.Links;
 import uk.gov.companieshouse.pscfiling.api.model.entity.PscIndividualFiling;
-import uk.gov.companieshouse.pscfiling.api.service.FilingValidationService;
 import uk.gov.companieshouse.pscfiling.api.service.PscFilingService;
 import uk.gov.companieshouse.pscfiling.api.service.TransactionService;
 import uk.gov.companieshouse.pscfiling.api.utils.LogHelper;
-import uk.gov.companieshouse.pscfiling.api.validator.FilingValidationContext;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
 @RestController
@@ -47,18 +45,15 @@ public class PscIndividualFilingControllerImpl implements PscIndividualFilingCon
     private final TransactionService transactionService;
     private final PscFilingService pscFilingService;
     private final PscMapper filingMapper;
-    private final FilingValidationService validatorService;
     private final Clock clock;
     private final Logger logger;
 
     public PscIndividualFilingControllerImpl(final TransactionService transactionService,
                                              final PscFilingService pscFilingService, final PscMapper filingMapper,
-                                             final FilingValidationService validatorService, final Clock clock,
-                                             final Logger logger) {
+                                             final Clock clock, final Logger logger) {
         this.transactionService = transactionService;
         this.pscFilingService = pscFilingService;
         this.filingMapper = filingMapper;
-        this.validatorService = validatorService;
         this.clock = clock;
         this.logger = logger;
     }
@@ -90,9 +85,6 @@ public class PscIndividualFilingControllerImpl implements PscIndividualFilingCon
         final var transaction = transactionService.getTransaction(transId, passthroughHeader);
         logger.infoContext(transId, "transaction found", logMap);
 
-        validatorService.validate(
-                new FilingValidationContext<>(dto, validationErrors, transaction, pscType,
-                        passthroughHeader));
         if (!validationErrors.isEmpty()) {
             throw new InvalidFilingException(validationErrors);
         }

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/model/dto/PscDtoCommunal.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/model/dto/PscDtoCommunal.java
@@ -2,8 +2,6 @@ package uk.gov.companieshouse.pscfiling.api.model.dto;
 
 import java.time.LocalDate;
 import java.util.List;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import javax.validation.constraints.PastOrPresent;
 
 public interface PscDtoCommunal {
@@ -11,7 +9,6 @@ public interface PscDtoCommunal {
 
     Boolean getAddressSameAsRegisteredOfficeAddress();
 
-    @NotNull
     @PastOrPresent
     LocalDate getCeasedOn();
 
@@ -19,15 +16,12 @@ public interface PscDtoCommunal {
 
     LocalDate getNotifiedOn();
 
-    @NotBlank
     String getReferenceEtag();
 
-    @NotBlank
     String getReferencePscId();
 
     String getReferencePscListEtag();
 
-    @NotNull
     @PastOrPresent
     LocalDate getRegisterEntryDate();
 }

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/validator/TerminationRequiredFieldsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/validator/TerminationRequiredFieldsValidator.java
@@ -8,31 +8,36 @@ import uk.gov.companieshouse.pscfiling.api.model.dto.PscDtoCommunal;
 public class TerminationRequiredFieldsValidator extends BaseIndividualFilingValidator
         implements IndividualFilingValid {
 
+    protected static final String OBJECT_NAME = "object";
+    protected static final String DEFAULT_MESSAGE = "must not be null";
+
     @Override
     public <T extends PscDtoCommunal> void validate(final FilingValidationContext<T> validationContext) {
 
         if (validationContext.getDto().getCeasedOn() == null) {
             validationContext.getErrors()
-                    .add(new FieldError("object", "ceased_on", null, false,
+                    .add(new FieldError(OBJECT_NAME, "ceased_on", null, false,
                             new String[]{null, "ceased_on"},
-                            null,"must not be null"));
+                            null, DEFAULT_MESSAGE));
         }
         if (validationContext.getDto().getRegisterEntryDate() == null) {
             validationContext.getErrors()
-                    .add(new FieldError("object", "register_entry_date", null, false,
+                    .add(new FieldError(OBJECT_NAME, "register_entry_date", null, false,
                             new String[]{null, "register_entry_date"},
-                            null,"must not be null"));
+                            null, DEFAULT_MESSAGE));
         }
         if (validationContext.getDto().getReferencePscId() == null) {
             validationContext.getErrors()
-                    .add(new FieldError("object", "reference_psc_id", null, false, new String[]{null, "reference_psc_id"},
-                            null, "must not be null"));
+                    .add(new FieldError(
+                            OBJECT_NAME, "reference_psc_id", null, false,
+                            new String[]{null, "reference_psc_id"},
+                            null, DEFAULT_MESSAGE));
         }
         if (validationContext.getDto().getReferenceEtag() == null) {
             validationContext.getErrors()
-                    .add(new FieldError("object", "reference_etag", null,
-                            false, new String[]{null, "reference_etag"},
-                            null, "must not be null"));
+                    .add(new FieldError(OBJECT_NAME, "reference_etag", null, false,
+                            new String[]{null, "reference_etag"},
+                            null, DEFAULT_MESSAGE));
         }
 
         // Only if required fields are present, should 'business' validation proceed

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/validator/TerminationRequiredFieldsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/validator/TerminationRequiredFieldsValidator.java
@@ -14,13 +14,13 @@ public class TerminationRequiredFieldsValidator extends BaseIndividualFilingVali
         if (validationContext.getDto().getCeasedOn() == null) {
             validationContext.getErrors()
                     .add(new FieldError("object", "ceased_on", null, false,
-                            new String[]{null, "date.ceased_on"},
+                            new String[]{null, "ceased_on"},
                             null,"must not be null"));
         }
         if (validationContext.getDto().getRegisterEntryDate() == null) {
             validationContext.getErrors()
                     .add(new FieldError("object", "register_entry_date", null, false,
-                            new String[]{null, "date.register_entry_date"},
+                            new String[]{null, "register_entry_date"},
                             null,"must not be null"));
         }
         if (validationContext.getDto().getReferencePscId() == null) {

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/validator/TerminationRequiredFieldsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/validator/TerminationRequiredFieldsValidator.java
@@ -1,0 +1,44 @@
+package uk.gov.companieshouse.pscfiling.api.validator;
+
+import org.springframework.stereotype.Component;
+import org.springframework.validation.FieldError;
+import uk.gov.companieshouse.pscfiling.api.model.dto.PscDtoCommunal;
+
+@Component
+public class TerminationRequiredFieldsValidator extends BaseIndividualFilingValidator
+        implements IndividualFilingValid {
+
+    @Override
+    public <T extends PscDtoCommunal> void validate(final FilingValidationContext<T> validationContext) {
+
+        if (validationContext.getDto().getCeasedOn() == null) {
+            validationContext.getErrors()
+                    .add(new FieldError("object", "ceased_on", null, false,
+                            new String[]{null, "date.ceased_on"},
+                            null,"must not be null"));
+        }
+        if (validationContext.getDto().getRegisterEntryDate() == null) {
+            validationContext.getErrors()
+                    .add(new FieldError("object", "register_entry_date", null, false,
+                            new String[]{null, "date.register_entry_date"},
+                            null,"must not be null"));
+        }
+        if (validationContext.getDto().getReferencePscId() == null) {
+            validationContext.getErrors()
+                    .add(new FieldError("object", "reference_psc_id", null, false, new String[]{null, "reference_psc_id"},
+                            null, "must not be null"));
+        }
+        if (validationContext.getDto().getReferenceEtag() == null) {
+            validationContext.getErrors()
+                    .add(new FieldError("object", "reference_etag", null,
+                            false, new String[]{null, "reference_etag"},
+                            null, "must not be null"));
+        }
+
+        // Only if required fields are present, should 'business' validation proceed
+        if (validationContext.getErrors().isEmpty()) {
+            super.validate(validationContext);
+        }
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/config/ValidatorConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/config/ValidatorConfigTest.java
@@ -14,10 +14,13 @@ import uk.gov.companieshouse.pscfiling.api.validator.PscEtagValidator;
 import uk.gov.companieshouse.pscfiling.api.validator.PscExistsValidator;
 import uk.gov.companieshouse.pscfiling.api.validator.PscIsActiveValidator;
 import uk.gov.companieshouse.pscfiling.api.validator.PscRegisterEntryDateValidator;
+import uk.gov.companieshouse.pscfiling.api.validator.TerminationRequiredFieldsValidator;
 
 @ExtendWith(MockitoExtension.class)
 class ValidatorConfigTest {
     private ValidatorConfig testConfig;
+    @Mock
+    private TerminationRequiredFieldsValidator terminationRequiredFieldsValidator;
     @Mock
     private PscExistsValidator pscExistsValidator;
     @Mock
@@ -36,9 +39,10 @@ class ValidatorConfigTest {
 
     @Test
     void filingForIndividualValid() {
-        final var valid = testConfig.filingForIndividualValid(pscExistsValidator, pscEtagValidator, ceasedOnDateValidator, pscRegisterEntryDateValidator,pscIsActiveValidator);
+        final var valid = testConfig.filingForIndividualValid(terminationRequiredFieldsValidator, pscExistsValidator,
+                pscEtagValidator, ceasedOnDateValidator, pscRegisterEntryDateValidator, pscIsActiveValidator);
 
         assertThat(valid.getPscType(), is(PscTypeConstants.INDIVIDUAL));
-        assertThat(valid.getFirst(), is(pscExistsValidator));
+        assertThat(valid.getFirst(), is(terminationRequiredFieldsValidator));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscWithIdentificationFilingControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscWithIdentificationFilingControllerImplIT.java
@@ -1,7 +1,22 @@
 package uk.gov.companieshouse.pscfiling.api.controller;
 
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import java.time.Clock;
-import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -14,49 +29,22 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.validation.FieldError;
 import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.companieshouse.api.error.ApiError;
-import uk.gov.companieshouse.api.error.ApiErrorResponse;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.model.psc.PscApi;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.pscfiling.api.error.ErrorType;
 import uk.gov.companieshouse.pscfiling.api.error.LocationType;
-import uk.gov.companieshouse.pscfiling.api.exception.FilingResourceNotFoundException;
 import uk.gov.companieshouse.pscfiling.api.mapper.PscMapper;
 import uk.gov.companieshouse.pscfiling.api.model.PscTypeConstants;
-import uk.gov.companieshouse.pscfiling.api.model.dto.PscDtoCommunal;
-import uk.gov.companieshouse.pscfiling.api.model.dto.PscIndividualDto;
 import uk.gov.companieshouse.pscfiling.api.model.dto.PscWithIdentificationDto;
 import uk.gov.companieshouse.pscfiling.api.model.entity.PscCommunal;
-import uk.gov.companieshouse.pscfiling.api.model.entity.PscIndividualFiling;
 import uk.gov.companieshouse.pscfiling.api.model.entity.PscWithIdentificationFiling;
-import uk.gov.companieshouse.pscfiling.api.service.FilingValidationService;
 import uk.gov.companieshouse.pscfiling.api.service.PscDetailsService;
 import uk.gov.companieshouse.pscfiling.api.service.PscFilingService;
 import uk.gov.companieshouse.pscfiling.api.service.TransactionService;
-import uk.gov.companieshouse.pscfiling.api.validator.FilingValidationContext;
 import uk.gov.companieshouse.pscfiling.api.validator.PscExistsValidator;
-
-import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasSize;
-import static org.mockito.AdditionalAnswers.answerVoid;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Tag("web")
 @Import(PscExistsValidator.class)
@@ -352,27 +340,44 @@ class PscWithIdentificationFilingControllerImplIT extends BaseControllerIT {
     }
 
     @Test
-    void createFilingWhenCeasedOnDateBlankThenResponse400() throws Exception {
+    void createFilingWhenCeasedOnDateBlankThenResponse201() throws Exception {
         final var body = "{" + PSC07_FRAGMENT.replace("2022-09-13", "") + "}";
-        final var expectedError =
-                createExpectedValidationError("must not be null", "$.ceased_on", 1, 75);
+        final var dto = PscWithIdentificationDto.builder().referenceEtag(ETAG)
+                .referencePscId(PSC_ID)
+                .ceasedOn(null)
+                .registerEntryDate(REGISTER_ENTRY_DATE)
+                .build();
+        final var filing = PscWithIdentificationFiling.builder().referenceEtag(ETAG)
+                .referencePscId(PSC_ID)
+                .ceasedOn(null)
+                .registerEntryDate(REGISTER_ENTRY_DATE)
+                .build();
+        final var locationUri = UriComponentsBuilder.fromPath("/")
+                .pathSegment("transactions", TRANS_ID,
+                        "persons-with-significant-control/corporate-entity", FILING_ID)
+                .build();
 
+        when(filingMapper.map(dto)).thenReturn(filing);
         when(transactionService.getTransaction(TRANS_ID, PASSTHROUGH_HEADER)).thenReturn(
                 transaction);
+        when(pscDetailsService.getPscDetails(transaction, PSC_ID, PscTypeConstants.INDIVIDUAL,
+                PASSTHROUGH_HEADER)).thenReturn(pscDetails);
+        when(pscDetails.getName()).thenReturn("Mr Joe Bloggs");
+        when(pscFilingService.save(any(PscWithIdentificationFiling.class), eq(TRANS_ID))).thenReturn(
+                        PscWithIdentificationFiling.builder(filing).id(FILING_ID)
+                                .build()) // copy of 'filing' with id=FILING_ID
+                .thenAnswer(i -> PscWithIdentificationFiling.builder(i.getArgument(0))
+                        .build()); // copy of first argument
+        when(clock.instant()).thenReturn(FIRST_INSTANT);
 
         mockMvc.perform(post(URL_PSC_CORPORATE_ENTITY, TRANS_ID).content(body)
                         .contentType(APPLICATION_JSON)
                         .headers(httpHeaders))
                 .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(header().doesNotExist("location"))
-                .andExpect(jsonPath("$.errors", hasSize(1)))
-                .andExpect(jsonPath("$.errors[0]",
-                        allOf(hasEntry("location", expectedError.getLocation()),
-                                hasEntry("location_type", expectedError.getLocationType()),
-                                hasEntry("type", expectedError.getType()))))
-                .andExpect(jsonPath("$.errors[0].error", containsString("must not be null")))
-                .andExpect(jsonPath("$.errors[0].error_values", is(nullValue())));
+                .andExpect(status().isCreated())
+                .andExpect(header().string("location", locationUri.toUriString()))
+                .andExpect(jsonPath("$").doesNotExist());
+        verify(filingMapper).map(dto);
     }
 
     @Disabled("Pending PSC-71 + PSC-72")

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/validator/TerminationRequiredFieldsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/validator/TerminationRequiredFieldsValidatorTest.java
@@ -1,0 +1,111 @@
+package uk.gov.companieshouse.pscfiling.api.validator;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.validation.FieldError;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.pscfiling.api.model.PscTypeConstants;
+import uk.gov.companieshouse.pscfiling.api.model.dto.PscIndividualDto;
+
+@ExtendWith(MockitoExtension.class)
+class TerminationRequiredFieldsValidatorTest {
+
+    @Mock
+    private Transaction transaction;
+    @Mock
+    private PscIndividualDto dto;
+
+    TerminationRequiredFieldsValidator testValidator;
+    private PscTypeConstants pscType;
+    private List<FieldError> errors;
+    private String passthroughHeader;
+
+    private static final String PSC_ID = "1kdaTltWeaP1EB70SSD9SLmiK5Y";
+    private static final String ETAG = "1234567";
+    private static final LocalDate DATE = LocalDate.of(2020, 5, 10);
+
+    @BeforeEach
+    void setUp() {
+        errors = new ArrayList<>();
+        pscType = PscTypeConstants.INDIVIDUAL;
+        passthroughHeader = "passthroughHeader";
+
+        when(dto.getReferencePscId()).thenReturn(PSC_ID);
+        when(dto.getCeasedOn()).thenReturn(DATE);
+        when(dto.getRegisterEntryDate()).thenReturn(DATE);
+        when(dto.getReferenceEtag()).thenReturn(ETAG);
+
+        testValidator = new TerminationRequiredFieldsValidator();
+    }
+
+    @Test
+    void validateAllDataPresent() {
+        testValidator.validate(new FilingValidationContext<>(dto, errors, transaction, pscType, passthroughHeader));
+
+        assertThat(errors, is(empty()));
+    }
+
+    @Test
+    void validatePscIdNotPresent() {
+        var fieldError =
+                new FieldError("object", "reference_psc_id", null, false, new String[]{null, "reference_psc_id"}, null,
+                        "must not be null");
+        when(dto.getReferencePscId()).thenReturn(null);
+
+        testValidator.validate(new FilingValidationContext<>(dto, errors, transaction, pscType, passthroughHeader));
+
+        assertThat(errors.stream().findFirst().orElseThrow(), equalTo(fieldError));
+        assertThat(errors, contains(fieldError));
+    }
+
+    @Test
+    void validateEtagNotPresent() {
+        var fieldError =
+                new FieldError("object", "reference_etag", null, false, new String[]{null, "reference_etag"}, null,
+                        "must not be null");
+        when(dto.getReferenceEtag()).thenReturn(null);
+
+        testValidator.validate(new FilingValidationContext<>(dto, errors, transaction, pscType, passthroughHeader));
+
+        assertThat(errors.stream().findFirst().orElseThrow(), equalTo(fieldError));
+        assertThat(errors, contains(fieldError));
+    }
+
+    @Test
+    void validateCeasedOnDateNotPresent() {
+        var fieldError = new FieldError("object", "ceased_on", null, false, new String[]{null, "ceased_on"}, null,
+                "must not be null");
+        when(dto.getCeasedOn()).thenReturn(null);
+
+        testValidator.validate(new FilingValidationContext<>(dto, errors, transaction, pscType, passthroughHeader));
+
+        assertThat(errors.stream().findFirst().orElseThrow(), equalTo(fieldError));
+        assertThat(errors, contains(fieldError));
+    }
+
+    @Test
+    void validateRegisterEntryDateNotPresent() {
+        var fieldError = new FieldError("object", "register_entry_date", null, false, new String[]{null, "register_entry_date"}, null,
+                "must not be null");
+        when(dto.getRegisterEntryDate()).thenReturn(null);
+
+        testValidator.validate(new FilingValidationContext<>(dto, errors, transaction, pscType, passthroughHeader));
+
+        assertThat(errors.stream().findFirst().orElseThrow(), equalTo(fieldError));
+        assertThat(errors, contains(fieldError));
+    }
+}
+


### PR DESCRIPTION
- removing the null check from data submitted, but leaving the `@PastOrPresent` annotation for dates so POST's of missing data will be accepted
- not doing 'business' validation in POST endpoint
- adding an extra validator to check required fields for Termination

PSC-129