### PR TITLE
Add check that the GET request url matches the resource

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/BaseFilingControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/BaseFilingControllerImpl.java
@@ -1,0 +1,89 @@
+package uk.gov.companieshouse.pscfiling.api.controller;
+
+import java.time.Clock;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.Errors;
+import uk.gov.companieshouse.api.model.transaction.Resource;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.pscfiling.api.exception.InvalidFilingException;
+import uk.gov.companieshouse.pscfiling.api.mapper.PscMapper;
+import uk.gov.companieshouse.pscfiling.api.model.entity.Links;
+import uk.gov.companieshouse.pscfiling.api.service.PscFilingService;
+import uk.gov.companieshouse.pscfiling.api.service.TransactionService;
+import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
+
+public class BaseFilingControllerImpl {
+    public static final String VALIDATION_STATUS = "validation_status";
+    protected final TransactionService transactionService;
+    protected final PscFilingService pscFilingService;
+    protected final PscMapper filingMapper;
+    protected final Clock clock;
+    protected final Logger logger;
+    private String passThroughHeader;
+
+    public BaseFilingControllerImpl(final TransactionService transactionService,
+                                    final PscFilingService pscFilingService, final PscMapper filingMapper,
+                                    final Clock clock, final Logger logger) {
+        this.transactionService = transactionService;
+        this.pscFilingService = pscFilingService;
+        this.filingMapper = filingMapper;
+        this.clock = clock;
+        this.logger = logger;
+    }
+
+    protected static void checkBindingErrors(BindingResult bindingResult) {
+        final var validationErrors = Optional.ofNullable(bindingResult).map(Errors::getFieldErrors).map(ArrayList::new)
+                .orElseGet(ArrayList::new);
+
+        if (!validationErrors.isEmpty()) {
+            throw new InvalidFilingException(validationErrors);
+        }
+    }
+
+    protected String getPassthroughHeader(HttpServletRequest request) {
+        if (passThroughHeader == null) {
+            passThroughHeader = request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
+        }
+        return passThroughHeader;
+    }
+
+    protected Transaction getTransaction(String transId, Transaction transaction, Map<String, Object> logMap,
+                                         String passthroughHeader) {
+        if (transaction == null) {
+            transaction = transactionService.getTransaction(transId, passthroughHeader);
+        }
+
+        logger.infoContext(transId, "transaction found", logMap);
+        return transaction;
+    }
+
+    protected void updateTransactionResources(Transaction transaction, Links links) {
+        Objects.requireNonNull(passThroughHeader);
+        final var resourceMap = buildResourceMap(links);
+
+        transaction.setResources(resourceMap);
+        transactionService.updateTransaction(transaction, passThroughHeader);
+    }
+
+    private Map<String, Resource> buildResourceMap(final Links links) {
+        final Map<String, Resource> resourceMap = new HashMap<>();
+        final var resource = new Resource();
+        final var linksMap = new HashMap<>(
+                Map.of("resource", links.getSelf().toString(), VALIDATION_STATUS,
+                        links.getValidationStatus().toString()));
+
+        resource.setKind("psc-filing");
+        resource.setLinks(linksMap);
+        resource.setUpdatedAt(clock.instant().atZone(ZoneId.systemDefault()).toLocalDateTime());
+        resourceMap.put(links.getSelf().toString(), resource);
+        return resourceMap;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/PscIndividualFilingController.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/PscIndividualFilingController.java
@@ -48,7 +48,8 @@ public interface PscIndividualFilingController {
     default ResponseEntity<PscDtoCommunal> getFilingForReview(
             @PathVariable("transactionId") String transId,
             @PathVariable("pscType") final PscTypeConstants pscType,
-            @PathVariable("filingResource") String filingResource) {
+            @PathVariable("filingResource") String filingResource,
+            final HttpServletRequest request) {
         throw new NotImplementedException();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/PscIndividualFilingControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/PscIndividualFilingControllerImpl.java
@@ -1,12 +1,8 @@
 package uk.gov.companieshouse.pscfiling.api.controller;
 
 import java.time.Clock;
-import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -14,7 +10,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.bson.types.ObjectId;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,10 +18,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
-import uk.gov.companieshouse.api.model.transaction.Resource;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.pscfiling.api.exception.InvalidFilingException;
 import uk.gov.companieshouse.pscfiling.api.mapper.PscMapper;
 import uk.gov.companieshouse.pscfiling.api.model.PscTypeConstants;
 import uk.gov.companieshouse.pscfiling.api.model.dto.PscDtoCommunal;
@@ -36,28 +29,17 @@ import uk.gov.companieshouse.pscfiling.api.model.entity.PscIndividualFiling;
 import uk.gov.companieshouse.pscfiling.api.service.PscFilingService;
 import uk.gov.companieshouse.pscfiling.api.service.TransactionService;
 import uk.gov.companieshouse.pscfiling.api.utils.LogHelper;
-import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
 @RestController
 @RequestMapping(
         "/transactions/{transactionId}/persons-with-significant-control/{pscType:"
                 + "(?:individual)}")
-public class PscIndividualFilingControllerImpl implements PscIndividualFilingController {
-    public static final String VALIDATION_STATUS = "validation_status";
-    private final TransactionService transactionService;
-    private final PscFilingService pscFilingService;
-    private final PscMapper filingMapper;
-    private final Clock clock;
-    private final Logger logger;
+public class PscIndividualFilingControllerImpl extends BaseFilingControllerImpl implements PscIndividualFilingController {
 
     public PscIndividualFilingControllerImpl(final TransactionService transactionService,
                                              final PscFilingService pscFilingService, final PscMapper filingMapper,
                                              final Clock clock, final Logger logger) {
-        this.transactionService = transactionService;
-        this.pscFilingService = pscFilingService;
-        this.filingMapper = filingMapper;
-        this.clock = clock;
-        this.logger = logger;
+        super(transactionService, pscFilingService, filingMapper, clock, logger);
     }
 
     /**
@@ -83,28 +65,13 @@ public class PscIndividualFilingControllerImpl implements PscIndividualFilingCon
 
         logger.debugRequest(request, "POST", logMap);
 
-        final var validationErrors = Optional.ofNullable(bindingResult)
-                .map(Errors::getFieldErrors).map(ArrayList::new)
-                .orElseGet(ArrayList::new);
-        final var passthroughHeader =
-                request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
+        checkBindingErrors(bindingResult);
 
-        if (transaction == null) {
-            transaction = transactionService.getTransaction(transId, passthroughHeader);
-        }
-
-        logger.infoContext(transId, "transaction found", logMap);
-
-        if (!validationErrors.isEmpty()) {
-            throw new InvalidFilingException(validationErrors);
-        }
+        transaction = getTransaction(transId, transaction, logMap, getPassthroughHeader(request));
 
         final var entity = filingMapper.map(dto);
         final var links = saveFilingWithLinks(entity, transId, request, logMap);
-        final var resourceMap = buildResourceMap(links);
-
-        transaction.setResources(resourceMap);
-        transactionService.updateTransaction(transaction, passthroughHeader);
+        updateTransactionResources(transaction, links);
 
         return ResponseEntity.created(links.getSelf())
                 .build();
@@ -134,24 +101,10 @@ public class PscIndividualFilingControllerImpl implements PscIndividualFilingCon
                         .build());
     }
 
-    private Map<String, Resource> buildResourceMap(final Links links) {
-        final Map<String, Resource> resourceMap = new HashMap<>();
-        final var resource = new Resource();
-        final var linksMap = new HashMap<>(
-                Map.of("resource", links.getSelf().toString(), VALIDATION_STATUS,
-                        links.getValidationStatus().toString()));
-
-        resource.setKind("psc-filing");
-        resource.setLinks(linksMap);
-        resource.setUpdatedAt(clock.instant().atZone(ZoneId.systemDefault()).toLocalDateTime());
-        resourceMap.put(links.getSelf().toString(), resource);
-        return resourceMap;
-    }
-
     private Links saveFilingWithLinks(final PscIndividualFiling entity, final String transId,
                                       final HttpServletRequest request, final Map<String, Object> logMap) {
         final var saved = pscFilingService.save(entity, transId);
-        final var links = buildLinks(saved, request);
+        final var links = buildLinks(request, saved);
         final var updated = PscIndividualFiling.builder(saved).links(links)
                 .build();
         final var resaved = pscFilingService.save(updated, transId);
@@ -162,7 +115,7 @@ public class PscIndividualFilingControllerImpl implements PscIndividualFilingCon
         return links;
     }
 
-    private Links buildLinks(final PscIndividualFiling savedFiling, final HttpServletRequest request) {
+    private Links buildLinks(final HttpServletRequest request, final PscIndividualFiling savedFiling) {
         final var objectId = new ObjectId(Objects.requireNonNull(savedFiling.getId()));
         final var selfUri = UriComponentsBuilder
                 .fromUriString(request.getRequestURI())

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/PscIndividualFilingControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/PscIndividualFilingControllerImpl.java
@@ -122,11 +122,12 @@ public class PscIndividualFilingControllerImpl implements PscIndividualFilingCon
     public ResponseEntity<PscDtoCommunal> getFilingForReview(
             @PathVariable("transactionId") final String transId,
             @PathVariable("pscType") final PscTypeConstants pscType,
-            @PathVariable("filingResourceId") final String filingResource) {
+            @PathVariable("filingResourceId") final String filingResource,
+            final HttpServletRequest request) {
 
         final var maybePSCFiling = pscFilingService.get(filingResource, transId);
 
-        final var maybeDto = maybePSCFiling.map(filingMapper::map);
+        final var maybeDto = maybePSCFiling.filter(f -> pscFilingService.requestMatchesResource(request, f)).map(filingMapper::map);
 
         return maybeDto.map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound()

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/PscWithIdentificationFilingController.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/PscWithIdentificationFilingController.java
@@ -50,7 +50,8 @@ public interface PscWithIdentificationFilingController {
     default ResponseEntity<PscDtoCommunal> getFilingForReview(
             @PathVariable("transactionId") final String transId,
             @PathVariable("pscType") final PscTypeConstants pscType,
-            @PathVariable("filingResource") final String filingResource) {
+            @PathVariable("filingResource") final String filingResource,
+            final HttpServletRequest request) {
         throw new NotImplementedException();
     }
 

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/PscWithIdentificationFilingControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/PscWithIdentificationFilingControllerImpl.java
@@ -124,11 +124,12 @@ public class PscWithIdentificationFilingControllerImpl implements PscWithIdentif
     public ResponseEntity<PscDtoCommunal> getFilingForReview(
             @PathVariable("transactionId") final String transId,
             @PathVariable("pscType") final PscTypeConstants pscType,
-            @PathVariable("filingResourceId") final String filingResource) {
+            @PathVariable("filingResourceId") final String filingResource,
+            final HttpServletRequest request) {
 
         final var maybePSCFiling = pscFilingService.get(filingResource, transId);
 
-        final var maybeDto = maybePSCFiling.map(filingMapper::map);
+        final var maybeDto = maybePSCFiling.filter(f -> pscFilingService.requestMatchesResource(request, f)).map(filingMapper::map);
 
         return maybeDto.map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound()

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/PscWithIdentificationFilingControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/PscWithIdentificationFilingControllerImpl.java
@@ -2,11 +2,9 @@ package uk.gov.companieshouse.pscfiling.api.controller;
 
 import java.time.Clock;
 import java.time.ZoneId;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -14,7 +12,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.bson.types.ObjectId;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,7 +23,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.companieshouse.api.model.transaction.Resource;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.pscfiling.api.exception.InvalidFilingException;
 import uk.gov.companieshouse.pscfiling.api.mapper.PscMapper;
 import uk.gov.companieshouse.pscfiling.api.model.PscTypeConstants;
 import uk.gov.companieshouse.pscfiling.api.model.dto.PscDtoCommunal;
@@ -36,28 +32,18 @@ import uk.gov.companieshouse.pscfiling.api.model.entity.PscWithIdentificationFil
 import uk.gov.companieshouse.pscfiling.api.service.PscFilingService;
 import uk.gov.companieshouse.pscfiling.api.service.TransactionService;
 import uk.gov.companieshouse.pscfiling.api.utils.LogHelper;
-import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
 @RestController
 @RequestMapping("/transactions/{transactionId}/persons-with-significant-control/{pscType:"
         + "(?:legal-person|corporate-entity)}")
-public class PscWithIdentificationFilingControllerImpl implements PscWithIdentificationFilingController {
-    public static final String VALIDATION_STATUS = "validation_status";
-    private final TransactionService transactionService;
-    private final PscFilingService pscFilingService;
-    private final Clock clock;
-    private final Logger logger;
-    private final PscMapper filingMapper;
+public class PscWithIdentificationFilingControllerImpl extends BaseFilingControllerImpl implements PscWithIdentificationFilingController {
 
     public PscWithIdentificationFilingControllerImpl(final TransactionService transactionService,
                                                      final PscFilingService pscFilingService, final PscMapper filingMapper,
                                                      final Clock clock,
                                                      final Logger logger) {
-        this.transactionService = transactionService;
-        this.pscFilingService = pscFilingService;
-        this.filingMapper = filingMapper;
-        this.clock = clock;
-        this.logger = logger;
+        super(transactionService, pscFilingService, filingMapper, clock, logger);
+
     }
 
     /**
@@ -83,30 +69,13 @@ public class PscWithIdentificationFilingControllerImpl implements PscWithIdentif
 
         logger.debugRequest(request, "POST", logMap);
 
-        final var validationErrors = Optional.ofNullable(bindingResult)
-                .map(Errors::getFieldErrors)
-                .map(ArrayList::new)
-                .orElseGet(ArrayList::new);
-        final var passthroughHeader =
-                request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
+        checkBindingErrors(bindingResult);
 
-        if (transaction == null) {
-            transaction = transactionService.getTransaction(transId, passthroughHeader);
-        }
-
-        logger.infoContext(transId, "transaction found", logMap);
-
-        if (!validationErrors.isEmpty()) {
-            throw new InvalidFilingException(validationErrors);
-        }
+        transaction = getTransaction(transId, transaction, logMap, getPassthroughHeader(request));
 
         final var entity = filingMapper.map(dto);
-        final var links = saveFilingWithLinks(entity, transId, request, logMap,
-            pscType);
-        final var resourceMap = buildResourceMap(links);
-
-        transaction.setResources(resourceMap);
-        transactionService.updateTransaction(transaction, passthroughHeader);
+        final var links = saveFilingWithLinks(entity, transId, request, logMap, pscType);
+        updateTransactionResources(transaction, links);
 
         return ResponseEntity.created(links.getSelf())
                 .build();

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/service/PscFilingService.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/service/PscFilingService.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.pscfiling.api.service;
 
 import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
 import uk.gov.companieshouse.pscfiling.api.model.entity.PscCommunal;
 import uk.gov.companieshouse.pscfiling.api.model.entity.PscIndividualFiling;
 import uk.gov.companieshouse.pscfiling.api.model.entity.PscWithIdentificationFiling;
@@ -14,4 +15,6 @@ public interface PscFilingService {
     PscWithIdentificationFiling save(PscWithIdentificationFiling filing, String transactionId);
 
     Optional<PscCommunal> get(String pscFilingId, String transactionId);
+
+    boolean requestMatchesResource(HttpServletRequest request, PscCommunal pscFiling);
 }

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/service/PscFilingServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/service/PscFilingServiceImpl.java
@@ -1,6 +1,9 @@
 package uk.gov.companieshouse.pscfiling.api.service;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.pscfiling.api.model.entity.PscCommunal;
@@ -78,4 +81,15 @@ public class PscFilingServiceImpl implements PscFilingService {
         return withIdentificationFilingRepository.save(filing);
     }
 
+    @Override
+    public boolean requestMatchesResource(HttpServletRequest request, PscCommunal pscFiling) {
+        URI selfLinkUri = pscFiling.getLinks().getSelf();
+        URI requestUri = null;
+        try {
+            requestUri = new URI(request.getRequestURI());
+        } catch (URISyntaxException e) {
+            return false;
+        }
+        return selfLinkUri.equals(requestUri.normalize());
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/service/PscFilingServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/service/PscFilingServiceImpl.java
@@ -83,7 +83,7 @@ public class PscFilingServiceImpl implements PscFilingService {
 
     @Override
     public boolean requestMatchesResource(HttpServletRequest request, PscCommunal pscFiling) {
-        URI selfLinkUri = pscFiling.getLinks().getSelf();
+        var selfLinkUri = pscFiling.getLinks().getSelf();
         URI requestUri = null;
         try {
             requestUri = new URI(request.getRequestURI());

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscIndividualFilingControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscIndividualFilingControllerImplTest.java
@@ -209,13 +209,25 @@ class PscIndividualFilingControllerImplTest {
     void getFilingForReviewWhenFound() {
 
         when(filingMapper.map((PscCommunal) filing)).thenReturn(dto);
+        when(pscFilingService.requestMatchesResource(request,filing)).thenReturn(true);
 
         when(pscFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.of(filing));
 
-        final var response = testController.getFilingForReview(TRANS_ID, PSC_TYPE, FILING_ID);
+        final var response = testController.getFilingForReview(TRANS_ID, PSC_TYPE, FILING_ID, request);
 
         assertThat(response.getStatusCode(), is(HttpStatus.OK));
         assertThat(response.getBody(), is(dto));
+    }
+
+    @Test
+    void getFilingForReviewWhenFoundButResourceNotMatched() {
+        when(pscFilingService.requestMatchesResource(request,filing)).thenReturn(false);
+
+        when(pscFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.of(filing));
+
+        final var response = testController.getFilingForReview(TRANS_ID, PSC_TYPE, FILING_ID, request);
+
+        assertThat(response.getStatusCode(), is(HttpStatus.NOT_FOUND));
     }
 
     @Test
@@ -223,7 +235,7 @@ class PscIndividualFilingControllerImplTest {
 
         when(pscFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.empty());
 
-        final var response = testController.getFilingForReview(TRANS_ID, PSC_TYPE, FILING_ID);
+        final var response = testController.getFilingForReview(TRANS_ID, PSC_TYPE, FILING_ID, request);
 
         assertThat(response.getStatusCode(), is(HttpStatus.NOT_FOUND));
     }

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscIndividualFilingControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscIndividualFilingControllerImplTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.companieshouse.pscfiling.api.controller.PscIndividualFilingControllerImpl.VALIDATION_STATUS;
+import static uk.gov.companieshouse.pscfiling.api.controller.BaseFilingControllerImpl.VALIDATION_STATUS;
 import static uk.gov.companieshouse.pscfiling.api.model.entity.Links.PREFIX_PRIVATE;
 
 import java.net.URI;
@@ -180,8 +180,6 @@ class PscIndividualFilingControllerImplTest {
     @Test
     void createFilingWhenRequestHasBindingError() {
         when(result.getFieldErrors()).thenReturn(List.of(fieldErrorWithRejectedValue));
-        when(request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader())).thenReturn(
-                PASSTHROUGH_HEADER);
 
         final var exception = assertThrows(InvalidFilingException.class,
                 () -> testController.createFiling(TRANS_ID, PscTypeConstants.INDIVIDUAL, transaction,

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscIndividualFilingControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscIndividualFilingControllerTest.java
@@ -38,6 +38,6 @@ class PscIndividualFilingControllerTest {
     void getFilingForReview() {
         assertThrows(NotImplementedException.class,
                 () -> testController.getFilingForReview("trans-id", PscTypeConstants.INDIVIDUAL,
-                        "filing-resource-id"));
+                        "filing-resource-id", request));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscWithIdentificationFilingControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscWithIdentificationFilingControllerImplTest.java
@@ -201,6 +201,7 @@ class PscWithIdentificationFilingControllerImplTest {
         when(filingMapper.map((PscCommunal) filing)).thenReturn(dto);
 
         when(pscFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.of(filing));
+        when(pscFilingService.requestMatchesResource(request,filing)).thenReturn(true);
 
         final var response = testController.getFilingForReview(TRANS_ID, PSC_TYPE, FILING_ID, request);
 

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscWithIdentificationFilingControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscWithIdentificationFilingControllerImplTest.java
@@ -1,5 +1,15 @@
 package uk.gov.companieshouse.pscfiling.api.controller;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.pscfiling.api.controller.BaseFilingControllerImpl.VALIDATION_STATUS;
+import static uk.gov.companieshouse.pscfiling.api.model.entity.Links.PREFIX_PRIVATE;
+
 import java.net.URI;
 import java.time.Clock;
 import java.time.Instant;
@@ -38,16 +48,6 @@ import uk.gov.companieshouse.pscfiling.api.service.TransactionService;
 import uk.gov.companieshouse.pscfiling.api.validator.FilingForPscTypeValidChain;
 import uk.gov.companieshouse.pscfiling.api.validator.PscExistsValidator;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.refEq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static uk.gov.companieshouse.pscfiling.api.controller.PscIndividualFilingControllerImpl.VALIDATION_STATUS;
-import static uk.gov.companieshouse.pscfiling.api.model.entity.Links.PREFIX_PRIVATE;
 
 @ExtendWith(MockitoExtension.class)
 class PscWithIdentificationFilingControllerImplTest {
@@ -170,8 +170,6 @@ class PscWithIdentificationFilingControllerImplTest {
     @Test
     void createFilingWhenRequestHasBindingError() {
         when(result.getFieldErrors()).thenReturn(List.of(fieldErrorWithRejectedValue));
-        when(request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader())).thenReturn(
-                PASSTHROUGH_HEADER);
 
         final var exception = assertThrows(InvalidFilingException.class,
                 () -> testController.createFiling(TRANS_ID, PscTypeConstants.CORPORATE_ENTITY, transaction,

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscWithIdentificationFilingControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscWithIdentificationFilingControllerImplTest.java
@@ -202,10 +202,21 @@ class PscWithIdentificationFilingControllerImplTest {
 
         when(pscFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.of(filing));
 
-        final var response = testController.getFilingForReview(TRANS_ID, PSC_TYPE, FILING_ID);
+        final var response = testController.getFilingForReview(TRANS_ID, PSC_TYPE, FILING_ID, request);
 
         assertThat(response.getStatusCode(), is(HttpStatus.OK));
         assertThat(response.getBody(), is(dto));
+    }
+
+    @Test
+    void getFilingForReviewWhenFoundButResourceNotMatched() {
+        when(pscFilingService.requestMatchesResource(request,filing)).thenReturn(false);
+
+        when(pscFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.of(filing));
+
+        final var response = testController.getFilingForReview(TRANS_ID, PSC_TYPE, FILING_ID, request);
+
+        assertThat(response.getStatusCode(), is(HttpStatus.NOT_FOUND));
     }
 
     @Test
@@ -213,7 +224,7 @@ class PscWithIdentificationFilingControllerImplTest {
 
         when(pscFilingService.get(FILING_ID, TRANS_ID)).thenReturn(Optional.empty());
 
-        final var response = testController.getFilingForReview(TRANS_ID, PSC_TYPE, FILING_ID);
+        final var response = testController.getFilingForReview(TRANS_ID, PSC_TYPE, FILING_ID, request);
 
         assertThat(response.getStatusCode(), is(HttpStatus.NOT_FOUND));
     }

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscWithIdentificationFilingControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscWithIdentificationFilingControllerTest.java
@@ -38,6 +38,6 @@ class PscWithIdentificationFilingControllerTest {
     void getFilingForReview() {
         assertThrows(NotImplementedException.class,
                 () -> testController.getFilingForReview("trans-id", PscTypeConstants.CORPORATE_ENTITY,
-                        "filing-resource-id"));
+                        "filing-resource-id", request));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/service/PscFilingServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/service/PscFilingServiceImplTest.java
@@ -2,17 +2,23 @@ package uk.gov.companieshouse.pscfiling.api.service;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.pscfiling.api.model.entity.Links;
 import uk.gov.companieshouse.pscfiling.api.model.entity.PscIndividualFiling;
+import uk.gov.companieshouse.pscfiling.api.model.entity.PscWithIdentificationFiling;
 import uk.gov.companieshouse.pscfiling.api.repository.PscFilingRepository;
 import uk.gov.companieshouse.pscfiling.api.repository.PscIndividualFilingRepository;
 import uk.gov.companieshouse.pscfiling.api.repository.PscWithIdentificationFilingRepository;
@@ -33,6 +39,10 @@ class PscFilingServiceImplTest {
     @Mock
     private PscIndividualFiling filing;
     @Mock
+    private PscWithIdentificationFiling identificationFiling;
+    @Mock
+    private HttpServletRequest request;
+    @Mock
     private Logger logger;
     @Mock
     private LogHelper logHelper;
@@ -44,12 +54,18 @@ class PscFilingServiceImplTest {
     }
 
     @Test
-    void save() {
+    void saveIndividual() {
         testService.save(filing, TRANS_ID);
 
         verify(individualFilingRepository).save(filing);
     }
 
+    @Test
+    void saveWithIdentification() {
+        testService.save(identificationFiling, TRANS_ID);
+
+        verify(withIdentificationFilingRepository).save(identificationFiling);
+    }
     @Test
     void getWhenFound() {
         final var filing = PscIndividualFiling.builder()
@@ -68,4 +84,35 @@ class PscFilingServiceImplTest {
         assertThat(pscIndividualFiling.isPresent(), is(false));
     }
 
+    @Test
+    void requestMatchesResource() throws URISyntaxException {
+        var links = new Links(new URI("transactions/" + TRANS_ID), new URI("validation_status"));
+
+        when(filing.getLinks()).thenReturn(links);
+        when(request.getRequestURI()).thenReturn("transactions/" + TRANS_ID);
+
+        assertThat(testService.requestMatchesResource(request, filing), is(true));
+    }
+
+    @Test
+    void requestDoesNotMatchResource() throws URISyntaxException {
+        var links = new Links(new URI("transactions/" + TRANS_ID), new URI("validation_status"));
+
+        when(filing.getLinks()).thenReturn(links);
+        when(request.getRequestURI()).thenReturn("different");
+
+        assertThat(testService.requestMatchesResource(request, filing), is(false));
+    }
+
+    @Test
+    void requestMatchesResourceThrowsException() throws URISyntaxException {
+        var links = new Links(new URI("transactions/" + TRANS_ID), new URI("validation_status"));
+
+        when(filing.getLinks()).thenReturn(links);
+        when(request.getRequestURI()).thenReturn(":");
+
+        var thrown = assertThrows(URISyntaxException.class, () -> new URI(":"));
+        assertThat(thrown.getMessage(), is("Expected scheme name at index 0: :"));
+        assertThat(testService.requestMatchesResource(request, filing), is(false));
+    }
 }


### PR DESCRIPTION
- checks that the request url matches the resource in the GET filing endpoints, this will include the PSC type used in the request
- returns 404 if fails
- refactoring done in Controllers to reduce the code duplication

PSC-141
PSC-137
PSC-146