### PR TITLE
PSC-151 remove eric passthrough from update transaction PATCH request

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/BaseFilingControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/BaseFilingControllerImpl.java
@@ -27,7 +27,6 @@ public class BaseFilingControllerImpl {
     protected final PscMapper filingMapper;
     protected final Clock clock;
     protected final Logger logger;
-    private String passThroughHeader;
 
     public BaseFilingControllerImpl(final TransactionService transactionService,
                                     final PscFilingService pscFilingService, final PscMapper filingMapper,
@@ -49,10 +48,7 @@ public class BaseFilingControllerImpl {
     }
 
     protected String getPassthroughHeader(HttpServletRequest request) {
-        if (passThroughHeader == null) {
-            passThroughHeader = request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
-        }
-        return passThroughHeader;
+        return request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
     }
 
     protected Transaction getTransaction(String transId, Transaction transaction, Map<String, Object> logMap,
@@ -66,11 +62,9 @@ public class BaseFilingControllerImpl {
     }
 
     protected void updateTransactionResources(Transaction transaction, Links links) {
-        Objects.requireNonNull(passThroughHeader);
         final var resourceMap = buildResourceMap(links);
-
         transaction.setResources(resourceMap);
-        transactionService.updateTransaction(transaction, passThroughHeader);
+        transactionService.updateTransaction(transaction);
     }
 
     private Map<String, Resource> buildResourceMap(final Links links) {

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/service/TransactionService.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/service/TransactionService.java
@@ -23,10 +23,9 @@ public interface TransactionService {
      * Update a Transaction by ID.
      *
      * @param transaction the Transaction object to update
-     * @param ericPassThroughHeader includes authorisation for transaction update
      *
      * @throws TransactionServiceException if Transaction not found or an error occurred
      */
-    void updateTransaction(Transaction transaction, final String ericPassThroughHeader)
+    void updateTransaction(Transaction transaction)
             throws TransactionServiceException;
 }

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/service/TransactionServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/service/TransactionServiceImpl.java
@@ -71,18 +71,17 @@ public class TransactionServiceImpl implements TransactionService {
      * Update a given transaction via the transaction service.
      *
      * @param transaction           the Transaction ID
-     * @param ericPassThroughHeader includes authorisation for transaction update
      * @throws TransactionServiceException if the transaction update failed
      */
     @Override
-    public void updateTransaction(final Transaction transaction, final String ericPassThroughHeader)
+    public void updateTransaction(final Transaction transaction)
             throws TransactionServiceException {
         final var logMap = LogHelper.createLogMap(transaction.getId());
         try {
             logger.debugContext(transaction.getId(), "Updating transaction", logMap);
             final var uri = PREFIX_PRIVATE + "/transactions/" + transaction.getId();
             final var resp =
-                    apiClientService.getInternalApiClient(ericPassThroughHeader)
+                    apiClientService.getInternalApiClient()
                             .privateTransaction()
                             .patch(uri, transaction)
                             .execute();

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscIndividualFilingControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscIndividualFilingControllerImplTest.java
@@ -138,7 +138,7 @@ class PscIndividualFilingControllerImplTest {
 
         // refEq needed to compare Map value objects; Resource does not override equals()
         verify(transaction).setResources(refEq(resourceMap));
-        verify(transactionService).updateTransaction(transaction, PASSTHROUGH_HEADER);
+        verify(transactionService).updateTransaction(transaction);
         final var context =
                 new FilingValidationContext<>(dto, validationErrors, transaction, PSC_TYPE,
                         PASSTHROUGH_HEADER);
@@ -169,7 +169,7 @@ class PscIndividualFilingControllerImplTest {
 
         // refEq needed to compare Map value objects; Resource does not override equals()
         verify(transaction).setResources(refEq(resourceMap));
-        verify(transactionService).updateTransaction(transaction, PASSTHROUGH_HEADER);
+        verify(transactionService).updateTransaction(transaction);
         final var context =
             new FilingValidationContext<>(dto, validationErrors, transaction, PSC_TYPE,
                 PASSTHROUGH_HEADER);

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscWithIdentificationFilingControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscWithIdentificationFilingControllerImplTest.java
@@ -136,7 +136,7 @@ class PscWithIdentificationFilingControllerImplTest {
 
         // refEq needed to compare Map value objects; Resource does not override equals()
         verify(transaction).setResources(refEq(resourceMap));
-        verify(transactionService).updateTransaction(transaction, PASSTHROUGH_HEADER);
+        verify(transactionService).updateTransaction(transaction);
         assertThat(response.getStatusCode(), is(HttpStatus.CREATED));
     }
 
@@ -163,7 +163,7 @@ class PscWithIdentificationFilingControllerImplTest {
 
         // refEq needed to compare Map value objects; Resource does not override equals()
         verify(transaction).setResources(refEq(resourceMap));
-        verify(transactionService).updateTransaction(transaction, PASSTHROUGH_HEADER);
+        verify(transactionService).updateTransaction(transaction);
         assertThat(response.getStatusCode(), is(HttpStatus.CREATED));
     }
 

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/service/TransactionServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/service/TransactionServiceImplTest.java
@@ -75,10 +75,9 @@ class TransactionServiceImplTest {
         when(transactionsResourceHandler.get("/transactions/" + TRANS_ID)).thenReturn(
                 transactionsGet);
         when(apiClient.transactions()).thenReturn(transactionsResourceHandler);
-        when(apiClientService.getApiClient(PASSTHROUGH_HEADER)).thenReturn(
-                apiClient);
+        when(apiClientService.getApiClient(PASSTHROUGH_HEADER)).thenReturn(apiClient);
 
-        var transaction = testService.getTransaction(TRANS_ID, PASSTHROUGH_HEADER);
+        var transaction = testService.getTransaction(TRANS_ID,PASSTHROUGH_HEADER);
 
         assertThat(transaction, samePropertyValuesAs(testTransaction(TRANS_ID)));
     }
@@ -89,7 +88,7 @@ class TransactionServiceImplTest {
                 IOException.class);
 
         assertThrows(TransactionServiceException.class,
-                () -> testService.getTransaction(TRANS_ID, PASSTHROUGH_HEADER));
+                () -> testService.getTransaction(TRANS_ID,PASSTHROUGH_HEADER));
     }
 
     @Test
@@ -99,7 +98,7 @@ class TransactionServiceImplTest {
         when(apiClientService.getApiClient(PASSTHROUGH_HEADER)).thenThrow(exception);
 
         final var thrown = assertThrows(TransactionServiceException.class,
-                () -> testService.getTransaction(TRANS_ID, PASSTHROUGH_HEADER));
+                () -> testService.getTransaction(TRANS_ID,PASSTHROUGH_HEADER));
 
         assertThat(thrown.getMessage(), is("Error Updating Transaction details for " + TRANS_ID + ": 404 test case"));
     }
@@ -110,23 +109,13 @@ class TransactionServiceImplTest {
         when(privateTransactionResourceHandler.patch("/private/transactions/12345",
                 testTransaction)).thenReturn(privateTransactionPatch);
         when(internalApiClient.privateTransaction()).thenReturn(privateTransactionResourceHandler);
-        when(apiClientService.getInternalApiClient(PASSTHROUGH_HEADER)).thenReturn(
+        when(apiClientService.getInternalApiClient()).thenReturn(
                 internalApiClient);
 
         when(apiResponseVoid.getStatusCode()).thenReturn(HttpStatusCodes.STATUS_CODE_NO_CONTENT);
-        testService.updateTransaction(testTransaction, PASSTHROUGH_HEADER);
+        testService.updateTransaction(testTransaction);
 
         verify(apiResponseVoid).getStatusCode();
-    }
-
-    @Test
-    void updateTransactionWhenIoException() throws IOException {
-        when(apiClientService.getInternalApiClient(PASSTHROUGH_HEADER)).thenThrow(
-                new IOException("update test case"));
-
-        final var thrown = assertThrows(TransactionServiceException.class,
-                () -> testService.updateTransaction(testTransaction, PASSTHROUGH_HEADER));
-        assertThat(thrown.getMessage(), is("Error Updating Transaction 12345: update test case"));
     }
 
     @Test
@@ -135,13 +124,13 @@ class TransactionServiceImplTest {
         when(privateTransactionResourceHandler.patch("/private/transactions/12345",
                 testTransaction)).thenReturn(privateTransactionPatch);
         when(internalApiClient.privateTransaction()).thenReturn(privateTransactionResourceHandler);
-        when(apiClientService.getInternalApiClient(PASSTHROUGH_HEADER)).thenReturn(
+        when(apiClientService.getInternalApiClient()).thenReturn(
                 internalApiClient);
 
         when(apiResponseVoid.getStatusCode()).thenReturn(HttpStatusCodes.STATUS_CODE_NOT_FOUND);
 
         final var thrown = assertThrows(TransactionServiceException.class,
-                () -> testService.updateTransaction(testTransaction, PASSTHROUGH_HEADER));
+                () -> testService.updateTransaction(testTransaction));
         assertThat(thrown.getMessage(), is("Error Updating Transaction details for 12345: 404 Unexpected Status Code received"));
     }
 


### PR DESCRIPTION
Removed the eric passthrough as a field on the BaseController and enforced retrieving from the request