### PR TITLE
All requests go through Transaction Interceptor

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/config/InterceptorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/config/InterceptorConfig.java
@@ -26,6 +26,9 @@ public class InterceptorConfig implements WebMvcConfigurer {
             "/transactions/{transaction_id}/persons-with-significant-control/{pscType:"
                     + "(?:individual|corporate-entity|legal-person)}"
     };
+    static final String TRANSACTIONS = "/transactions/**";
+    static final String PRIVATE = "/private/**";
+    static final String[] TRANSACTIONS_LIST = {TRANSACTIONS, PRIVATE};
     public static final String PSC_FILING_API = "psc-filing-api";
 
     private TokenPermissionsInterceptor tokenPermissionsInterceptor;
@@ -59,7 +62,7 @@ public class InterceptorConfig implements WebMvcConfigurer {
 
     private void addTransactionInterceptor(InterceptorRegistry registry) {
         registry.addInterceptor(transactionInterceptor())
-                .addPathPatterns(INTERCEPTOR_PATHS_LIST);
+                .addPathPatterns(TRANSACTIONS_LIST);
     }
 
     private void addOpenTransactionInterceptor(InterceptorRegistry registry) {

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/config/InterceptorConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/config/InterceptorConfigTest.java
@@ -34,11 +34,7 @@ class InterceptorConfigTest {
     @Mock
     private TokenPermissionsInterceptor tokenPermissionsInterceptor;
     @Mock
-    private TransactionInterceptor transactionInterceptor;
-    @Mock
     private CompanyInterceptor companyInterceptor;
-    @Mock
-    private OpenTransactionInterceptor openTransactionInterceptor;
     @Mock
     private InterceptorRegistry interceptorRegistry;
     @Mock
@@ -76,7 +72,7 @@ class InterceptorConfigTest {
         inOrder.verify(interceptorRegistry).addInterceptor(tokenPermissionsInterceptor);
         inOrder.verify(interceptorRegistry)
                 .addInterceptor(any(MappablePermissionsInterceptor.class));
-        verify(interceptorRegistration, times(5))
+        verify(interceptorRegistration, times(4))
                 .addPathPatterns("/transactions/{transaction_id}/persons-with-significant-control/{pscType:(?:individual|corporate-entity|legal-person)}");
     }
 


### PR DESCRIPTION
The advantage here is that all requests will have the transaction details add as an attribute, and so don't need to be looked up again.

Note the existing `INTERCEPTOR_PATHS_LIST` could be renamed now to indicate that it excludes the `/filings` and `/validation_status` requests.  
But I've left it as is, until we add the other Interceptors and to rename the PATHS then.

PSC-143