### PR TITLE
Add Internal user Interceptor

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/config/InterceptorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/config/InterceptorConfig.java
@@ -9,6 +9,7 @@ import org.springframework.lang.NonNull;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import uk.gov.companieshouse.api.interceptor.ClosedTransactionInterceptor;
+import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
 import uk.gov.companieshouse.api.interceptor.MappablePermissionsInterceptor;
 import uk.gov.companieshouse.api.interceptor.OpenTransactionInterceptor;
 import uk.gov.companieshouse.api.interceptor.PermissionsMapping;
@@ -31,6 +32,7 @@ public class InterceptorConfig implements WebMvcConfigurer {
 
     private TokenPermissionsInterceptor tokenPermissionsInterceptor;
     private CompanyInterceptor companyInterceptor;
+    private InternalUserInterceptor internalUserInterceptor;
 
     @Autowired
     public void setTokenPermissionsInterceptor(
@@ -41,6 +43,11 @@ public class InterceptorConfig implements WebMvcConfigurer {
     @Autowired
     public void setCompanyInterceptor(final CompanyInterceptor companyInterceptor) {
         this.companyInterceptor = companyInterceptor;
+    }
+
+    @Autowired
+    public void setInternalUserInterceptor(InternalUserInterceptor internalUserInterceptor) {
+        this.internalUserInterceptor = internalUserInterceptor;
     }
 
     /**
@@ -57,6 +64,7 @@ public class InterceptorConfig implements WebMvcConfigurer {
         addTokenPermissionsInterceptor(registry);
         addRequestPermissionsInterceptor(registry);
         addTransactionClosedInterceptor(registry);
+        addInternalUserInterceptor(registry);
     }
 
     private void addTransactionInterceptor(final InterceptorRegistry registry) {
@@ -83,9 +91,14 @@ public class InterceptorConfig implements WebMvcConfigurer {
                 .order(5);
     }
 
+    private void addInternalUserInterceptor(final InterceptorRegistry registry) {
+        registry.addInterceptor(internalUserInterceptor)
+                .addPathPatterns(FILINGS_PATH).order(6);
+    }
+
     private void addTransactionClosedInterceptor(final InterceptorRegistry registry) {
         registry.addInterceptor(transactionClosedInterceptor())
-                .addPathPatterns(FILINGS_PATH).order(6);
+                .addPathPatterns(FILINGS_PATH).order(7);
     }
 
     @Bean

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/config/InterceptorConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/config/InterceptorConfigTest.java
@@ -15,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import uk.gov.companieshouse.api.interceptor.ClosedTransactionInterceptor;
+import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
 import uk.gov.companieshouse.api.interceptor.MappablePermissionsInterceptor;
 import uk.gov.companieshouse.api.interceptor.OpenTransactionInterceptor;
 import uk.gov.companieshouse.api.interceptor.PermissionsMapping;
@@ -32,6 +33,8 @@ class InterceptorConfigTest {
     private TokenPermissionsInterceptor tokenPermissionsInterceptor;
     @Mock
     private CompanyInterceptor companyInterceptor;
+    @Mock
+    private InternalUserInterceptor internalUserInterceptor;
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private InterceptorRegistry interceptorRegistry;
     @Mock
@@ -46,6 +49,7 @@ class InterceptorConfigTest {
     void addInterceptors() {
         testConfig.setTokenPermissionsInterceptor(tokenPermissionsInterceptor);
         testConfig.setCompanyInterceptor(companyInterceptor);
+        testConfig.setInternalUserInterceptor(internalUserInterceptor);
         testConfig.addInterceptors(interceptorRegistry);
 
         verify(interceptorRegistry.addInterceptor(any(TransactionInterceptor.class)))
@@ -58,12 +62,18 @@ class InterceptorConfigTest {
         verify(interceptorRegistry.addInterceptor(tokenPermissionsInterceptor)).order(4);
         verify(interceptorRegistry.addInterceptor(any(MappablePermissionsInterceptor.class)))
                 .order(5);
-        verify(interceptorRegistry.addInterceptor(any(ClosedTransactionInterceptor.class))
+        verify(interceptorRegistry.addInterceptor(any(InternalUserInterceptor.class))
                 .addPathPatterns("/private"
                         + "/transactions/{transaction_id}/persons-with-significant-control"
                         + "/{pscType:"
                         + "(?:individual|corporate-entity|legal-person)}"
                         + "/{filing_resource_id}/filings")).order(6);
+        verify(interceptorRegistry.addInterceptor(any(ClosedTransactionInterceptor.class))
+                .addPathPatterns("/private"
+                        + "/transactions/{transaction_id}/persons-with-significant-control"
+                        + "/{pscType:"
+                        + "(?:individual|corporate-entity|legal-person)}"
+                        + "/{filing_resource_id}/filings")).order(7);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/BaseControllerIT.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/BaseControllerIT.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
+import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
 import uk.gov.companieshouse.api.interceptor.OpenTransactionInterceptor;
 import uk.gov.companieshouse.api.interceptor.TransactionInterceptor;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
@@ -54,6 +55,8 @@ public class BaseControllerIT {
     protected OpenTransactionInterceptor openTransactionInterceptor;
     @MockBean
     protected CompanyInterceptor companyInterceptor;
+    @MockBean
+    protected InternalUserInterceptor internalUserInterceptor;
 
     void setUp() throws Exception {
         httpHeaders = new HttpHeaders();
@@ -62,6 +65,7 @@ public class BaseControllerIT {
         when(transactionInterceptor.preHandle(any(), any(), any())).thenReturn(true);
         when(openTransactionInterceptor.preHandle(any(), any(), any())).thenReturn(true);
         when(companyInterceptor.preHandle(any(), any(), any())).thenReturn(true);
+        when(internalUserInterceptor.preHandle(any(), any(), any())).thenReturn(true);
         transaction = createOpenTransaction();
     }
 


### PR DESCRIPTION
- means you have to use an API key with `"internal_app_privileges" : true` for the `/filings` endpoint
- I've checked that the `filing-resource-handler` service can successfully call this endpoint.
- the only query is the ordering - I've set it before the TransactionClosed Interceptor??

In the `account.api_client_keys` collection:
| Authorisation | Outcome |
|-----|-----|
| OAuth2 | 403 Forbidden |
| `API key with "internal_app_privileges" : false` | 401 Unauthorised |
| `API key with "internal_app_privileges" : true` | 200 Ok | 

PSC-138