### PR TITLE
Add PSC name and cessation date to filing description

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/config/InterceptorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/config/InterceptorConfig.java
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.PropertySource;
 import org.springframework.lang.NonNull;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/config/enumerations/ConstantsConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/config/enumerations/ConstantsConfig.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.pscfiling.api.config.ApiEnumerationsConfig;
+package uk.gov.companieshouse.pscfiling.api.config.enumerations;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/config/enumerations/PscFilingConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/config/enumerations/PscFilingConfig.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.pscfiling.api.config.ApiEnumerationsConfig;
+package uk.gov.companieshouse.pscfiling.api.config.enumerations;
 
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/ValidationStatusControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/ValidationStatusControllerImpl.java
@@ -27,7 +27,6 @@ import uk.gov.companieshouse.pscfiling.api.model.dto.PscDtoCommunal;
 import uk.gov.companieshouse.pscfiling.api.model.entity.PscCommunal;
 import uk.gov.companieshouse.pscfiling.api.service.FilingValidationService;
 import uk.gov.companieshouse.pscfiling.api.service.PscFilingService;
-import uk.gov.companieshouse.pscfiling.api.service.TransactionService;
 import uk.gov.companieshouse.pscfiling.api.utils.LogHelper;
 import uk.gov.companieshouse.pscfiling.api.validator.FilingValidationContext;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/enumerations/YamlPropertySourceFactory.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/enumerations/YamlPropertySourceFactory.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.pscfiling.api.enumerations;
 
-import java.io.IOException;
-import java.util.Properties;
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
 import org.springframework.core.env.PropertiesPropertySource;
 import org.springframework.core.env.PropertySource;
@@ -11,12 +9,11 @@ import org.springframework.core.io.support.PropertySourceFactory;
 public class YamlPropertySourceFactory implements PropertySourceFactory {
 
     @Override
-    public PropertySource<?> createPropertySource(String name, EncodedResource encodedResource)
-            throws IOException {
-        YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+    public PropertySource<?> createPropertySource(String name, EncodedResource encodedResource) {
+        var factory = new YamlPropertiesFactoryBean();
         factory.setResources(encodedResource.getResource());
 
-        Properties properties = factory.getObject();
+        var properties = factory.getObject();
 
         return new PropertiesPropertySource(encodedResource.getResource().getFilename(), properties);
     }

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/service/FilingDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/service/FilingDataServiceImpl.java
@@ -95,6 +95,8 @@ public class FilingDataServiceImpl implements FilingDataService {
                 // fall through
             case LEGAL_PERSON:
                 name = (String) filing.getData().get("name");
+                break;
+
         }
 
         var date = LocalDate.parse(filing.getData().get("ceased_on").toString());

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/service/FilingDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/service/FilingDataServiceImpl.java
@@ -1,6 +1,11 @@
 package uk.gov.companieshouse.pscfiling.api.service;
 
 import java.text.MessageFormat;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
 import uk.gov.companieshouse.api.model.psc.PscApi;
@@ -42,9 +47,9 @@ public class FilingDataServiceImpl implements FilingDataService {
             final Transaction transaction, final String passthroughHeader) {
         final var filing = new FilingApi();
         filing.setKind(MessageFormat.format("{0}#{1}", FilingKind.PSC_CESSATION.getValue(), pscType.getValue())); // TODO: handling other kinds to come later
-        filing.setDescription(filingDataConfig.getPsc07Description());
-
-        return populateFilingData(filing, filingId, pscType, transaction, passthroughHeader);
+        populateFilingData(filing, filingId, pscType, transaction, passthroughHeader);
+        setFilingDescription(filing, pscType);
+        return filing;
     }
 
     private FilingApi populateFilingData(final FilingApi filing, final String filingId,
@@ -73,4 +78,32 @@ public class FilingDataServiceImpl implements FilingDataService {
         return filing;
     }
 
+    private void setFilingDescription(FilingApi filing, final PscTypeConstants pscType) {
+        String name = "";
+        switch (pscType) {
+            case INDIVIDUAL:
+                String[] names = {
+                        (String) filing.getData().get("title"),
+                        (String) filing.getData().get("first_name"),
+                        (String) filing.getData().get("other_forenames"),
+                        (String) filing.getData().get("last_name")};
+                StringBuilder sb = new StringBuilder();
+                for (String str : names)
+                    if (str != null) {
+                        sb.append(str).append(" ");
+                    }
+                var result = sb.toString();
+                name = result.trim();
+                break;
+            case CORPORATE_ENTITY:
+                // fall through
+            case LEGAL_PERSON:
+                name = (String) filing.getData().get("name");
+        }
+
+        LocalDate date = LocalDate.parse(filing.getData().get("ceased_on").toString());
+        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+        String strDate = date.format(fmt);
+        filing.setDescription(MessageFormat.format(filingDataConfig.getPsc07Description(), name, strDate));
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/service/FilingDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/service/FilingDataServiceImpl.java
@@ -76,15 +76,14 @@ public class FilingDataServiceImpl implements FilingDataService {
     }
 
     private void setFilingDescription(FilingApi filing, final PscTypeConstants pscType) {
-        String name = "";
+        var name = "";
         switch (pscType) {
             case INDIVIDUAL:
-                String[] names = {
-                        (String) filing.getData().get("title"),
+                var names = new String[]{(String) filing.getData().get("title"),
                         (String) filing.getData().get("first_name"),
                         (String) filing.getData().get("other_forenames"),
                         (String) filing.getData().get("last_name")};
-                StringBuilder sb = new StringBuilder();
+                var sb = new StringBuilder();
                 for (String str : names)
                     if (str != null) {
                         sb.append(str).append(" ");
@@ -98,8 +97,8 @@ public class FilingDataServiceImpl implements FilingDataService {
                 name = (String) filing.getData().get("name");
         }
 
-        LocalDate date = LocalDate.parse(filing.getData().get("ceased_on").toString());
-        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+        var date = LocalDate.parse(filing.getData().get("ceased_on").toString());
+        var fmt = DateTimeFormatter.ofPattern("dd/MM/yyyy");
         String strDate = date.format(fmt);
         filing.setDescription(MessageFormat.format(filingDataConfig.getPsc07Description(), name, strDate));
     }

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/service/FilingDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/service/FilingDataServiceImpl.java
@@ -1,11 +1,8 @@
 package uk.gov.companieshouse.pscfiling.api.service;
 
 import java.text.MessageFormat;
-import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Arrays;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
 import uk.gov.companieshouse.api.model.psc.PscApi;

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/config/enumerations/ConstantsConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/config/enumerations/ConstantsConfigTest.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.pscfiling.api.config.ApiEnumerationsConfig;
+package uk.gov.companieshouse.pscfiling.api.config.enumerations;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/config/enumerations/PscFilingConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/config/enumerations/PscFilingConfigTest.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.pscfiling.api.config.ApiEnumerationsConfig;
+package uk.gov.companieshouse.pscfiling.api.config.enumerations;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/FilingDataControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/FilingDataControllerImplIT.java
@@ -26,7 +26,7 @@ import uk.gov.companieshouse.api.AttributeName;
 import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
 import uk.gov.companieshouse.api.model.transaction.TransactionStatus;
 import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.pscfiling.api.config.ApiEnumerationsConfig.PscFilingConfig;
+import uk.gov.companieshouse.pscfiling.api.config.enumerations.PscFilingConfig;
 import uk.gov.companieshouse.pscfiling.api.exception.FilingResourceNotFoundException;
 import uk.gov.companieshouse.pscfiling.api.model.FilingKind;
 import uk.gov.companieshouse.pscfiling.api.model.PscTypeConstants;

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PermissionInterceptorIT.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PermissionInterceptorIT.java
@@ -18,7 +18,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.companieshouse.api.model.psc.PscApi;
 import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.pscfiling.api.config.ApiEnumerationsConfig.PscFilingConfig;
+import uk.gov.companieshouse.pscfiling.api.config.enumerations.PscFilingConfig;
 import uk.gov.companieshouse.pscfiling.api.mapper.PscMapper;
 import uk.gov.companieshouse.pscfiling.api.service.FilingValidationService;
 import uk.gov.companieshouse.pscfiling.api.service.PscDetailsService;

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscIndividualFilingControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscIndividualFilingControllerImplIT.java
@@ -35,7 +35,7 @@ import uk.gov.companieshouse.api.error.ApiError;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.model.psc.PscApi;
 import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.pscfiling.api.config.ApiEnumerationsConfig.PscFilingConfig;
+import uk.gov.companieshouse.pscfiling.api.config.enumerations.PscFilingConfig;
 import uk.gov.companieshouse.pscfiling.api.error.ErrorType;
 import uk.gov.companieshouse.pscfiling.api.error.LocationType;
 import uk.gov.companieshouse.pscfiling.api.mapper.PscMapper;

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscWithIdentificationFilingControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/PscWithIdentificationFilingControllerImplIT.java
@@ -33,7 +33,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.companieshouse.api.error.ApiError;
 import uk.gov.companieshouse.api.model.psc.PscApi;
 import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.pscfiling.api.config.ApiEnumerationsConfig.PscFilingConfig;
+import uk.gov.companieshouse.pscfiling.api.config.enumerations.PscFilingConfig;
 import uk.gov.companieshouse.pscfiling.api.mapper.PscMapper;
 import uk.gov.companieshouse.pscfiling.api.model.PscTypeConstants;
 import uk.gov.companieshouse.pscfiling.api.model.dto.PscWithIdentificationDto;

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/ValidationStatusControllerImplFlagFalseIT.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/ValidationStatusControllerImplFlagFalseIT.java
@@ -19,7 +19,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.pscfiling.api.config.ApiEnumerationsConfig.PscFilingConfig;
+import uk.gov.companieshouse.pscfiling.api.config.enumerations.PscFilingConfig;
 import uk.gov.companieshouse.pscfiling.api.mapper.ErrorMapper;
 import uk.gov.companieshouse.pscfiling.api.mapper.PscMapper;
 import uk.gov.companieshouse.pscfiling.api.model.entity.PscIndividualFiling;

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/ValidationStatusControllerImplFlagNotBooleanIT.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/ValidationStatusControllerImplFlagNotBooleanIT.java
@@ -19,7 +19,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.pscfiling.api.config.ApiEnumerationsConfig.PscFilingConfig;
+import uk.gov.companieshouse.pscfiling.api.config.enumerations.PscFilingConfig;
 import uk.gov.companieshouse.pscfiling.api.mapper.ErrorMapper;
 import uk.gov.companieshouse.pscfiling.api.mapper.PscMapper;
 import uk.gov.companieshouse.pscfiling.api.model.entity.PscIndividualFiling;

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/ValidationStatusControllerImplFlagUndefinedIT.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/ValidationStatusControllerImplFlagUndefinedIT.java
@@ -20,7 +20,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.pscfiling.api.config.ApiEnumerationsConfig.PscFilingConfig;
+import uk.gov.companieshouse.pscfiling.api.config.enumerations.PscFilingConfig;
 import uk.gov.companieshouse.pscfiling.api.mapper.ErrorMapper;
 import uk.gov.companieshouse.pscfiling.api.mapper.PscMapper;
 import uk.gov.companieshouse.pscfiling.api.model.entity.PscIndividualFiling;

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/ValidationStatusControllerImplValidationIT.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/ValidationStatusControllerImplValidationIT.java
@@ -26,7 +26,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.companieshouse.api.model.psc.PscApi;
 import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.pscfiling.api.config.ApiEnumerationsConfig.PscFilingConfig;
+import uk.gov.companieshouse.pscfiling.api.config.enumerations.PscFilingConfig;
 import uk.gov.companieshouse.pscfiling.api.config.ValidatorConfig;
 import uk.gov.companieshouse.pscfiling.api.error.RestExceptionHandler;
 import uk.gov.companieshouse.pscfiling.api.exception.FilingResourceNotFoundException;

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/service/FilingDataServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/service/FilingDataServiceImplTest.java
@@ -76,6 +76,15 @@ class FilingDataServiceImplTest extends TestBaseService {
     private Transaction transaction;
     private FilingDataService testService;
 
+    @BeforeEach
+    void setUp() {
+        testService = new FilingDataServiceImpl(pscFilingService, dataMapper, pscDetailsService,
+                filingDataConfig, logger);
+        transaction = new Transaction();
+        transaction.setId(TRANS_ID);
+        transaction.setCompanyNumber(COMPANY_NUMBER);
+    }
+
     @ParameterizedTest
     @NullSource
     @ValueSource(strings = {OTHER_FORENAMES})
@@ -139,15 +148,6 @@ class FilingDataServiceImplTest extends TestBaseService {
         assertThat(filingApi.getKind(),
                 is(MessageFormat.format("{0}#{1}", FilingKind.PSC_CESSATION.getValue(), INDIVIDUAL)));
         assertThat(filingApi.getDescription(), is(expectedDescription));
-    }
-
-    @BeforeEach
-    void setUp() {
-        testService = new FilingDataServiceImpl(pscFilingService, dataMapper, pscDetailsService,
-                filingDataConfig, logger);
-        transaction = new Transaction();
-        transaction.setId(TRANS_ID);
-        transaction.setCompanyNumber(COMPANY_NUMBER);
     }
 
     @Test


### PR DESCRIPTION
Body for `/filings` response now:
```
    {
        "data": {
            "title": "Mr",
            "first_name": "Someone",
            "last_name": "Else",
            "ceased_on": "2023-03-09",
            "register_entry_date": "2023-03-09"
        },
        "description": "(PSC07) Notice of ceasing to be a Person of Significant Control for Someone Else on 09/03/2023",
        "description_identifier": null,
        "description_values": null,
        "kind": "psc-filing#cessation#individual"
    }
```



PSC-172