### PR TITLE
Correct validation messages when values missing

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/validator/TerminationRequiredFieldsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/validator/TerminationRequiredFieldsValidator.java
@@ -10,7 +10,6 @@ public class TerminationRequiredFieldsValidator extends BaseFilingValidator
         implements FilingValid {
 
     protected static final String OBJECT_NAME = "object";
-    protected static final String DEFAULT_MESSAGE = "must not be null";
 
     public TerminationRequiredFieldsValidator(Map<String, String> validation) {
         super(validation);
@@ -23,26 +22,26 @@ public class TerminationRequiredFieldsValidator extends BaseFilingValidator
             validationContext.getErrors()
                     .add(new FieldError(OBJECT_NAME, "ceased_on", null, false,
                             new String[]{null, "ceased_on"},
-                            null, DEFAULT_MESSAGE));
+                            null, validation.get("ceased-date-missing")));
         }
         if (validationContext.getDto().getRegisterEntryDate() == null) {
             validationContext.getErrors()
                     .add(new FieldError(OBJECT_NAME, "register_entry_date", null, false,
                             new String[]{null, "register_entry_date"},
-                            null, DEFAULT_MESSAGE));
+                            null, validation.get("register-date-missing")));
         }
         if (validationContext.getDto().getReferencePscId() == null) {
             validationContext.getErrors()
                     .add(new FieldError(
                             OBJECT_NAME, "reference_psc_id", null, false,
                             new String[]{null, "reference_psc_id"},
-                            null, DEFAULT_MESSAGE));
+                            null, validation.get("reference-psc-id-missing")));
         }
         if (validationContext.getDto().getReferenceEtag() == null) {
             validationContext.getErrors()
                     .add(new FieldError(OBJECT_NAME, "reference_etag", null, false,
                             new String[]{null, "reference_etag"},
-                            null, DEFAULT_MESSAGE));
+                            null, validation.get("reference-etag-missing")));
         }
 
         // Only if required fields are present, should 'business' validation proceed

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/validator/TerminationRequiredFieldsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/validator/TerminationRequiredFieldsValidatorTest.java
@@ -65,8 +65,10 @@ class TerminationRequiredFieldsValidatorTest {
     void validatePscIdNotPresent() {
         var fieldError =
                 new FieldError("object", "reference_psc_id", null, false, new String[]{null, "reference_psc_id"}, null,
-                        "must not be null");
+                        "Reference PSC ID must be entered");
         when(dto.getReferencePscId()).thenReturn(null);
+        when(validation.get("reference-psc-id-missing")).thenReturn(
+                "Reference PSC ID must be entered");
 
         testValidator.validate(new FilingValidationContext<>(dto, errors, transaction, pscType, passthroughHeader));
 
@@ -78,8 +80,10 @@ class TerminationRequiredFieldsValidatorTest {
     void validateEtagNotPresent() {
         var fieldError =
                 new FieldError("object", "reference_etag", null, false, new String[]{null, "reference_etag"}, null,
-                        "must not be null");
+                        "Reference ETag must be entered");
         when(dto.getReferenceEtag()).thenReturn(null);
+        when(validation.get("reference-etag-missing")).thenReturn(
+                "Reference ETag must be entered");
 
         testValidator.validate(new FilingValidationContext<>(dto, errors, transaction, pscType, passthroughHeader));
 
@@ -90,8 +94,10 @@ class TerminationRequiredFieldsValidatorTest {
     @Test
     void validateCeasedOnDateNotPresent() {
         var fieldError = new FieldError("object", "ceased_on", null, false, new String[]{null, "ceased_on"}, null,
-                "must not be null");
+                "Ceased date must be entered");
         when(dto.getCeasedOn()).thenReturn(null);
+        when(validation.get("ceased-date-missing")).thenReturn(
+                "Ceased date must be entered");
 
         testValidator.validate(new FilingValidationContext<>(dto, errors, transaction, pscType, passthroughHeader));
 
@@ -102,8 +108,10 @@ class TerminationRequiredFieldsValidatorTest {
     @Test
     void validateRegisterEntryDateNotPresent() {
         var fieldError = new FieldError("object", "register_entry_date", null, false, new String[]{null, "register_entry_date"}, null,
-                "must not be null");
+                "Register entry date must be entered");
         when(dto.getRegisterEntryDate()).thenReturn(null);
+        when(validation.get("register-date-missing")).thenReturn(
+                "Register entry date must be entered");
 
         testValidator.validate(new FilingValidationContext<>(dto, errors, transaction, pscType, passthroughHeader));
 


### PR DESCRIPTION
In an earlier PR I'd omitted amending the validation when values missing.
Now get this message for missing Reg entry date for example:
```
{
    "errors": [
        {
            "error": "Register entry date must be entered",
            "location": "$.register_entry_date",
            "type": "ch:validation",
            "location_type": "json-path"
        }
    ],
    "is_valid": false
}
```

PSC-187