### PR TITLE
Etag or PSC id is empty

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/validator/TerminationRequiredFieldsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/validator/TerminationRequiredFieldsValidator.java
@@ -30,14 +30,14 @@ public class TerminationRequiredFieldsValidator extends BaseFilingValidator
                             new String[]{null, "register_entry_date"},
                             null, validation.get("register-date-missing")));
         }
-        if (validationContext.getDto().getReferencePscId() == null) {
+        if (validationContext.getDto().getReferencePscId() == null || validationContext.getDto().getReferencePscId().isEmpty()) {
             validationContext.getErrors()
                     .add(new FieldError(
                             OBJECT_NAME, "reference_psc_id", null, false,
                             new String[]{null, "reference_psc_id"},
                             null, validation.get("reference-psc-id-missing")));
         }
-        if (validationContext.getDto().getReferenceEtag() == null) {
+        if (validationContext.getDto().getReferenceEtag() == null || validationContext.getDto().getReferenceEtag().isEmpty()) {
             validationContext.getErrors()
                     .add(new FieldError(OBJECT_NAME, "reference_etag", null, false,
                             new String[]{null, "reference_etag"},

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/validator/TerminationRequiredFieldsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/validator/TerminationRequiredFieldsValidatorTest.java
@@ -14,6 +14,9 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.validation.FieldError;
@@ -61,12 +64,14 @@ class TerminationRequiredFieldsValidatorTest {
         assertThat(errors, is(empty()));
     }
 
-    @Test
-    void validatePscIdNotPresent() {
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = "")
+    void validatePscIdNotPresent(String pscId) {
         var fieldError =
                 new FieldError("object", "reference_psc_id", null, false, new String[]{null, "reference_psc_id"}, null,
                         "Reference PSC ID must be entered");
-        when(dto.getReferencePscId()).thenReturn(null);
+        when(dto.getReferencePscId()).thenReturn(pscId);
         when(validation.get("reference-psc-id-missing")).thenReturn(
                 "Reference PSC ID must be entered");
 
@@ -76,12 +81,14 @@ class TerminationRequiredFieldsValidatorTest {
         assertThat(errors, contains(fieldError));
     }
 
-    @Test
-    void validateEtagNotPresent() {
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = "")
+    void validateEtagNotPresent(String etag) {
         var fieldError =
                 new FieldError("object", "reference_etag", null, false, new String[]{null, "reference_etag"}, null,
                         "Reference ETag must be entered");
-        when(dto.getReferenceEtag()).thenReturn(null);
+        when(dto.getReferenceEtag()).thenReturn(etag);
         when(validation.get("reference-etag-missing")).thenReturn(
                 "Reference ETag must be entered");
 


### PR DESCRIPTION
If `"reference_psc_id": ""` supplied in POST:

instead of ` "error": "Reference ID for PSC not found"`
now returns `"error": "Reference PSC ID must be entered"`

similar for Etag