### PR TITLE
Amend path pattern for Open Transaction Interceptor back to what it was

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/config/InterceptorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/config/InterceptorConfig.java
@@ -81,7 +81,7 @@ public class InterceptorConfig implements WebMvcConfigurer {
 
     private void addOpenTransactionInterceptor(final InterceptorRegistry registry) {
         registry.addInterceptor(openTransactionInterceptor())
-                .addPathPatterns(COMMON_INTERCEPTOR_RESOURCE_PATH).order(2);
+                .addPathPatterns(COMMON_INTERCEPTOR_PATH).order(2);
     }
 
     private void addCompanyInterceptor(final InterceptorRegistry registry) {

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/config/InterceptorConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/config/InterceptorConfigTest.java
@@ -60,8 +60,7 @@ class InterceptorConfigTest {
         verify(interceptorRegistry.addInterceptor(any(OpenTransactionInterceptor.class))
                 .addPathPatterns(
                         "/transactions/{transaction_id}/persons-with-significant-control/{pscType:"
-                                + "(?:individual|corporate-entity|legal-person)"
-                                + "}/{filing_resource_id}")).order(2);
+                                + "(?:individual|corporate-entity|legal-person)}")).order(2);
         verify(interceptorRegistry.addInterceptor(companyInterceptor)).order(3);
         verify(interceptorRegistry.addInterceptor(tokenPermissionsInterceptor)).order(4);
         verify(interceptorRegistry.addInterceptor(any(MappablePermissionsInterceptor.class)))


### PR DESCRIPTION
Open transaction interceptor should be used for POST request to create a PSC filing.
The `COMMON_INTERCEPTOR_RESOURCE_PATH` below has the Filing Id appended, so this means the Open Transaction Interceptor wouldn't be used.

PSC-229