### PR TITLE
Include path patterns for POST and PATCH requests to OpenTx Interceptor

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/config/InterceptorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/config/InterceptorConfig.java
@@ -84,7 +84,7 @@ public class InterceptorConfig implements WebMvcConfigurer {
 
     private void addOpenTransactionInterceptor(final InterceptorRegistry registry) {
         registry.addInterceptor(openTransactionInterceptor())
-                .addPathPatterns(COMMON_INTERCEPTOR_PATH).order(2);
+                .addPathPatterns(COMMON_INTERCEPTOR_PATH, COMMON_INTERCEPTOR_RESOURCE_PATH).order(2);
     }
 
     private void addCompanyInterceptor(final InterceptorRegistry registry) {

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/config/InterceptorConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/config/InterceptorConfigTest.java
@@ -60,7 +60,10 @@ class InterceptorConfigTest {
         verify(interceptorRegistry.addInterceptor(any(OpenTransactionInterceptor.class))
                 .addPathPatterns(
                         "/transactions/{transaction_id}/persons-with-significant-control/{pscType:"
-                                + "(?:individual|corporate-entity|legal-person)}")).order(2);
+                                + "(?:individual|corporate-entity|legal-person)}",
+                                "/transactions/{transaction_id}/persons-with-significant-control/{pscType:"
+                                + "(?:individual|corporate-entity|legal-person)}"
+                                + "/{filing_resource_id}")).order(2);
         verify(interceptorRegistry.addInterceptor(companyInterceptor)).order(3);
         verify(interceptorRegistry.addInterceptor(tokenPermissionsInterceptor)).order(4);
         verify(interceptorRegistry.addInterceptor(any(MappablePermissionsInterceptor.class)))


### PR DESCRIPTION
The Open Transaction Interceptor needs to run on:
- POST path `"/transactions/{transaction_id}/persons-with-significant-control/{pscType}"`
- and PATCH path `"/transactions/{transaction_id}/persons-with-significant-control/{pscType}/{filing_resource_id}"`

PSC-238

Note - my earlier fix for PSC-229 in #75 stopped the match for PATCH requests
