### PR TITLE
Cross-reference transaction_id and the filing_resource_id on PATCH endpoints

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/impl/PscIndividualFilingControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/impl/PscIndividualFilingControllerImpl.java
@@ -40,19 +40,21 @@ import uk.gov.companieshouse.pscfiling.api.utils.LogHelper;
 
 @RestController
 @RequestMapping(
-        "/transactions/{transactionId}/persons-with-significant-control/{pscType:"
-                + "(?:individual)}")
+    "/transactions/{transactionId}/persons-with-significant-control/{pscType:"
+        + "(?:individual)}")
 public class PscIndividualFilingControllerImpl extends BaseFilingControllerImpl implements
-        PscIndividualFilingController {
+    PscIndividualFilingController {
     private static final String PATCH_RESULT_MSG = "PATCH result";
     private static final String STATUS_MSG = "status";
+    private static final String PATCH_FAILED = "patch failed";
+    private static final String ERROR_MSG = "error";
 
     private final PscIndividualFilingService pscIndividualFilingService;
 
     public PscIndividualFilingControllerImpl(final TransactionService transactionService,
-            final PscFilingService pscFilingService,
-            final PscIndividualFilingService pscIndividualFilingService,
-            final PscMapper filingMapper, final Clock clock, final Logger logger) {
+        final PscFilingService pscFilingService,
+        final PscIndividualFilingService pscIndividualFilingService,
+        final PscMapper filingMapper, final Clock clock, final Logger logger) {
         super(transactionService, pscFilingService, filingMapper, clock, logger);
         this.pscIndividualFilingService = pscIndividualFilingService;
     }
@@ -117,24 +119,31 @@ public class PscIndividualFilingControllerImpl extends BaseFilingControllerImpl 
             final HttpServletRequest request) {
 
         final var logMap = LogHelper.createLogMap(transId);
+        final var maybePSCFiling = pscFilingService.get(filingResource).filter(
+            f -> pscFilingService.requestMatchesResourceSelf(request, f));
+
+        if (maybePSCFiling.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
         final var patchResult = pscIndividualFilingService.patch(filingResource, mergePatch);
 
         if (patchResult.failedRetrieval()) {
             final var reason = (RetrievalFailureReason) patchResult.getRetrievalFailureReason();
 
-            logMap.put(STATUS_MSG, "patch failed");
-            logMap.put("error", "retrieval failure: " + reason);
+            logMap.put(STATUS_MSG, PATCH_FAILED);
+            logMap.put(ERROR_MSG, "retrieval failure: " + reason);
             logger.debugContext(transId, PATCH_RESULT_MSG, logMap);
 
             throw new FilingResourceNotFoundException(
-                    "Failed to retrieve filing: " + filingResource);
+                "Failed to retrieve filing: " + filingResource);
         }
         else if (patchResult.failedValidation()) {
 
             final var errors = (List<FieldError>) patchResult.getValidationErrors();
 
-            logMap.put(STATUS_MSG, "patch failed");
-            logMap.put("error", "validation failure: " + errors);
+            logMap.put(STATUS_MSG, PATCH_FAILED);
+            logMap.put(ERROR_MSG, "validation failure: " + errors);
             logger.debugContext(transId, PATCH_RESULT_MSG, logMap);
 
             throw new InvalidPatchException(errors);

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/impl/PscWithIdentificationFilingControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/controller/impl/PscWithIdentificationFilingControllerImpl.java
@@ -40,20 +40,22 @@ import uk.gov.companieshouse.pscfiling.api.utils.LogHelper;
 
 @RestController
 @RequestMapping("/transactions/{transactionId}/persons-with-significant-control/{pscType:"
-        + "(?:legal-person|corporate-entity)}")
+    + "(?:legal-person|corporate-entity)}")
 public class PscWithIdentificationFilingControllerImpl extends BaseFilingControllerImpl
-        implements PscWithIdentificationFilingController {
+    implements PscWithIdentificationFilingController {
 
     private static final String PATCH_RESULT_MSG = "PATCH result";
     private static final String STATUS_MSG = "status";
+    private static final String PATCH_FAILED = "patch failed";
+    private static final String ERROR_MSG = "error";
 
     private final PscWithIdentificationFilingService pscWithIdentificationFilingService;
 
     public PscWithIdentificationFilingControllerImpl(final TransactionService transactionService,
-            final PscFilingService pscFilingService,
-            final PscWithIdentificationFilingService pscWithIdentificationFilingService,
-            final PscMapper filingMapper,
-            final Clock clock, final Logger logger) {
+        final PscFilingService pscFilingService,
+        final PscWithIdentificationFilingService pscWithIdentificationFilingService,
+        final PscMapper filingMapper,
+        final Clock clock, final Logger logger) {
         super(transactionService, pscFilingService, filingMapper, clock, logger);
 
         this.pscWithIdentificationFilingService = pscWithIdentificationFilingService;
@@ -119,24 +121,31 @@ public class PscWithIdentificationFilingControllerImpl extends BaseFilingControl
             final HttpServletRequest request) {
 
         final var logMap = LogHelper.createLogMap(transId);
+        final var maybePSCFiling = pscFilingService.get(filingResource).filter(
+            f -> pscFilingService.requestMatchesResourceSelf(request, f));
+
+        if (maybePSCFiling.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
         final var patchResult = pscWithIdentificationFilingService.patch(filingResource,
-                mergePatch);
+            mergePatch);
 
         if (patchResult.failedRetrieval()) {
             final var reason = (RetrievalFailureReason) patchResult.getRetrievalFailureReason();
 
-            logMap.put(STATUS_MSG, "patch failed");
-            logMap.put("error", "retrieval failure: " + reason);
+            logMap.put(STATUS_MSG, PATCH_FAILED);
+            logMap.put(ERROR_MSG, "retrieval failure: " + reason);
             logger.infoContext(transId, PATCH_RESULT_MSG, logMap);
 
             throw new FilingResourceNotFoundException(
-                    "Failed to retrieve filing: " + filingResource);
+                "Failed to retrieve filing: " + filingResource);
         }
         else if (patchResult.failedValidation()) {
             final var errors = (List<FieldError>) patchResult.getValidationErrors();
 
-            logMap.put(STATUS_MSG, "patch failed");
-            logMap.put("error", "validation failure: " + errors);
+            logMap.put(STATUS_MSG, PATCH_FAILED);
+            logMap.put(ERROR_MSG, "validation failure: " + errors);
             logger.infoContext(transId, PATCH_RESULT_MSG, logMap);
 
             throw new InvalidPatchException(errors);
@@ -145,11 +154,11 @@ public class PscWithIdentificationFilingControllerImpl extends BaseFilingControl
             logMap.put(STATUS_MSG, "patch successful");
             logger.infoContext(transId, PATCH_RESULT_MSG, logMap);
 
-            return pscWithIdentificationFilingService.get(filingResource)
-                    .map(PscWithIdentificationFiling.class::cast)
-                    .map(ResponseEntity::ok)
-                    .orElse(ResponseEntity.notFound()
-                            .build());
+            return pscFilingService.get(filingResource)
+                .map(PscWithIdentificationFiling.class::cast)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound()
+                    .build());
         }
 
     }

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/impl/PscIndividualFilingControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/impl/PscIndividualFilingControllerImplIT.java
@@ -503,7 +503,6 @@ class PscIndividualFilingControllerImplIT extends BaseControllerIT {
                 .andExpect(jsonPath("$.reference_etag", is(ETAG)))
                 .andExpect(jsonPath("$.reference_psc_id", is(PSC_ID)))
                 .andExpect(jsonPath("$.ceased_on", is(CEASED_ON_DATE.toString())));
-        verify(filingMapper).map(filing);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/impl/PscIndividualFilingControllerImplMergeIT.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/impl/PscIndividualFilingControllerImplMergeIT.java
@@ -41,18 +41,20 @@ import uk.gov.companieshouse.pscfiling.api.model.entity.Links;
 import uk.gov.companieshouse.pscfiling.api.model.entity.NameElements;
 import uk.gov.companieshouse.pscfiling.api.model.entity.NaturesOfControlList;
 import uk.gov.companieshouse.pscfiling.api.model.entity.PscIndividualFiling;
+import uk.gov.companieshouse.pscfiling.api.repository.PscFilingRepository;
 import uk.gov.companieshouse.pscfiling.api.repository.PscIndividualFilingRepository;
 import uk.gov.companieshouse.pscfiling.api.service.FilingValidationService;
 import uk.gov.companieshouse.pscfiling.api.service.PscDetailsService;
-import uk.gov.companieshouse.pscfiling.api.service.PscFilingService;
 import uk.gov.companieshouse.pscfiling.api.service.TransactionService;
 
 @Tag("app")
 @SpringBootTest
 @AutoConfigureMockMvc
 class PscIndividualFilingControllerImplMergeIT extends BaseControllerIT {
-    private static final URI SELF_URI = URI.create("/path/to/self");
-    private static final URI VALIDATION_URI = URI.create("/path/to/self/validation");
+    private static final String RESOURCE_URI_STR = String.format(
+        "/transactions/%s/persons-with-significant-control/individual/%s", TRANS_ID, FILING_ID);
+    private static final URI SELF_URI = URI.create(RESOURCE_URI_STR);
+    private static final URI VALIDATION_URI = URI.create(RESOURCE_URI_STR + "/validation_status");
     private NameElements nameElements;
     private NaturesOfControlList naturesOfControl;
     private Links links;
@@ -65,7 +67,7 @@ class PscIndividualFilingControllerImplMergeIT extends BaseControllerIT {
     @MockBean
     private PscApi pscDetails;
     @MockBean
-    private PscFilingService pscFilingService;
+    private PscFilingRepository filingRepository;
     @MockBean
     private PscIndividualFilingRepository individualFilingRepository;
     @MockBean
@@ -116,49 +118,49 @@ class PscIndividualFilingControllerImplMergeIT extends BaseControllerIT {
     @DisplayName("Expect to update or replace existing fields that are not read only")
     void updateFilingWhenReplacingFields() throws Exception {
         final var body = "{\n"
-                + " \"id\": \"unauthorised\",\n"
-                + "  \"ceased_on\": \"2022-03-03\",\n"
-                + " \"created_at\": \""
-                + SECOND_INSTANT
-                + "\",\n"
-                + " \"updated_at\": \""
-                + FIRST_INSTANT
-                + "\",\n"
-                + "  \"name_elements\": {\n"
-                + "    \"surname\": \"Replaced\"\n"
-                + "  },\n"
-                + " \"natures_of_control\": [\n"
-                + "    \"type4\"\n"
-                + "  ]\n"
-                + "}";
+            + " \"id\": \"unauthorised\",\n"
+            + "  \"ceased_on\": \"2022-03-03\",\n"
+            + " \"created_at\": \""
+            + SECOND_INSTANT
+            + "\",\n"
+            + " \"updated_at\": \""
+            + FIRST_INSTANT
+            + "\",\n"
+            + "  \"name_elements\": {\n"
+            + "    \"surname\": \"Replaced\"\n"
+            + "  },\n"
+            + " \"natures_of_control\": [\n"
+            + "    \"type4\"\n"
+            + "  ]\n"
+            + "}";
         final var filing = PscIndividualFiling.builder()
-                .id(FILING_ID)
-                .createdAt(FIRST_INSTANT)
-                .updatedAt(FIRST_INSTANT)
-                .referenceEtag(ETAG)
-                .referencePscId(PSC_ID)
-                .ceasedOn(CEASED_ON_DATE)
-                .registerEntryDate(REGISTER_ENTRY_DATE)
-                .nameElements(nameElements)
-                .naturesOfControl(naturesOfControl)
-                .links(links)
-                .build();
+            .id(FILING_ID)
+            .createdAt(FIRST_INSTANT)
+            .updatedAt(FIRST_INSTANT)
+            .referenceEtag(ETAG)
+            .referencePscId(PSC_ID)
+            .ceasedOn(CEASED_ON_DATE)
+            .registerEntryDate(REGISTER_ENTRY_DATE)
+            .nameElements(nameElements)
+            .naturesOfControl(naturesOfControl)
+            .links(links)
+            .build();
 
-        when(pscFilingService.get(FILING_ID)).thenReturn(Optional.of(filing));
-
-        when(pscFilingService.save(any(PscIndividualFiling.class))).thenAnswer(
-                i -> PscIndividualFiling.builder(i.getArgument(0))
-                        .build()); // copy of first argument
+        when(filingRepository.findById(FILING_ID)).thenReturn(Optional.of(filing));
+        when(individualFilingRepository.findById(FILING_ID)).thenReturn(Optional.of(filing));
+        when(individualFilingRepository.save(any(PscIndividualFiling.class))).thenAnswer(
+            i -> PscIndividualFiling.builder(i.getArgument(0))
+                .build()); // copy of first argument
         when(clock.instant()).thenReturn(SECOND_INSTANT);
 
         mockMvc.perform(patch(URL_PSC_INDIVIDUAL_RESOURCE, TRANS_ID, FILING_ID).content(body)
-                        .contentType(APPLICATION_JSON_MERGE_PATCH)
-                        .requestAttr("transaction", transaction)
-                        .headers(httpHeaders))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id", is(FILING_ID)))
-                .andExpect(jsonPath("$.ceased_on", is("2022-03-03")))
+                .contentType(APPLICATION_JSON_MERGE_PATCH)
+                .requestAttr("transaction", transaction)
+                .headers(httpHeaders))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id", is(FILING_ID)))
+            .andExpect(jsonPath("$.ceased_on", is("2022-03-03")))
                 .andExpect(jsonPath("$.name_elements.forename", is("Forename")))
                 .andExpect(jsonPath("$.name_elements.other_forenames", is("Other Forenames")))
                 .andExpect(jsonPath("$.name_elements.title", is("Sir")))
@@ -172,39 +174,40 @@ class PscIndividualFilingControllerImplMergeIT extends BaseControllerIT {
     @DisplayName("Expect to add new fields to existing filing")
     void updateFilingWhenAddingFields() throws Exception {
         final var body = "{\n"
-                + "  \"ceased_on\": \"2022-10-05\",\n"
-                + "  \"name_elements\": {\n"
-                + "    \"surname\": \"Added\"\n"
-                + "  },\n"
-                + " \"natures_of_control\": [\n"
-                + "    \"type1\",\n"
-                + "    \"type2\",\n"
-                + "    \"type3\",\n"
-                + "    \"type4\"\n"
-                + "  ]\n"
-                + "}";
+            + "  \"ceased_on\": \"2022-10-05\",\n"
+            + "  \"name_elements\": {\n"
+            + "    \"surname\": \"Added\"\n"
+            + "  },\n"
+            + " \"natures_of_control\": [\n"
+            + "    \"type1\",\n"
+            + "    \"type2\",\n"
+            + "    \"type3\",\n"
+            + "    \"type4\"\n"
+            + "  ]\n"
+            + "}";
         final var filing = PscIndividualFiling.builder()
-                .id(FILING_ID)
-                .referenceEtag(ETAG)
-                .referencePscId(PSC_ID)
-                .registerEntryDate(REGISTER_ENTRY_DATE)
-                .links(links)
-                .build();
+            .id(FILING_ID)
+            .referenceEtag(ETAG)
+            .referencePscId(PSC_ID)
+            .registerEntryDate(REGISTER_ENTRY_DATE)
+            .links(links)
+            .build();
 
-        when(pscFilingService.get(FILING_ID)).thenReturn(Optional.of(filing));
-        when(pscFilingService.save(any(PscIndividualFiling.class))).thenAnswer(
-                i -> PscIndividualFiling.builder(i.getArgument(0))
-                        .build()); // copy of first argument
+        when(filingRepository.findById(FILING_ID)).thenReturn(Optional.of(filing));
+        when(individualFilingRepository.findById(FILING_ID)).thenReturn(Optional.of(filing));
+        when(individualFilingRepository.save(any(PscIndividualFiling.class))).thenAnswer(
+            i -> PscIndividualFiling.builder(i.getArgument(0))
+                .build()); // copy of first argument
         when(clock.instant()).thenReturn(FIRST_INSTANT);
 
         mockMvc.perform(patch(URL_PSC_INDIVIDUAL_RESOURCE, TRANS_ID, FILING_ID).content(body)
-                        .contentType(APPLICATION_JSON_MERGE_PATCH)
-                        .requestAttr("transaction", transaction)
-                        .headers(httpHeaders))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id", is(FILING_ID)))
-                .andExpect(jsonPath("$.ceased_on", is(CEASED_ON)))
+                .contentType(APPLICATION_JSON_MERGE_PATCH)
+                .requestAttr("transaction", transaction)
+                .headers(httpHeaders))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id", is(FILING_ID)))
+            .andExpect(jsonPath("$.ceased_on", is(CEASED_ON)))
                 .andExpect(jsonPath("$.name_elements.forename").doesNotExist())
                 .andExpect(jsonPath("$.name_elements.other_forenames").doesNotExist())
                 .andExpect(jsonPath("$.name_elements.title").doesNotExist())
@@ -218,41 +221,42 @@ class PscIndividualFilingControllerImplMergeIT extends BaseControllerIT {
     @DisplayName("Expected: top level and nested fields are deleted with 'null' and read only fields are unchanged")
     void updateFilingWhenDeletingFields() throws Exception {
         final var body = "{\n"
-                + " \"id\": null,\n"
-                + "  \"ceased_on\": null,\n"
-                + "  \"name_elements\": {\n"
-                + "    \"surname\": null\n"
-                + "  },\n"
-                + " \"links\": {\n"
-                + "    \"self\": null\n"
-                + "  },\n"
-                + " \"natures_of_control\": [\n"
-                + "  ]\n"
-                + "}";
+            + " \"id\": null,\n"
+            + "  \"ceased_on\": null,\n"
+            + "  \"name_elements\": {\n"
+            + "    \"surname\": null\n"
+            + "  },\n"
+            + " \"links\": {\n"
+            + "    \"self\": null\n"
+            + "  },\n"
+            + " \"natures_of_control\": [\n"
+            + "  ]\n"
+            + "}";
         final var filing = PscIndividualFiling.builder()
-                .id(FILING_ID)
-                .referenceEtag(ETAG)
-                .referencePscId(PSC_ID)
-                .ceasedOn(CEASED_ON_DATE)
-                .nameElements(nameElements)
-                .links(links)
-                .registerEntryDate(REGISTER_ENTRY_DATE)
-                .build();
+            .id(FILING_ID)
+            .referenceEtag(ETAG)
+            .referencePscId(PSC_ID)
+            .ceasedOn(CEASED_ON_DATE)
+            .nameElements(nameElements)
+            .links(links)
+            .registerEntryDate(REGISTER_ENTRY_DATE)
+            .build();
 
-        when(pscFilingService.get(FILING_ID)).thenReturn(Optional.of(filing));
-        when(pscFilingService.save(any(PscIndividualFiling.class))).thenAnswer(
-                i -> PscIndividualFiling.builder(i.getArgument(0))
-                        .build()); // copy of first argument
+        when(filingRepository.findById(FILING_ID)).thenReturn(Optional.of(filing));
+        when(individualFilingRepository.findById(FILING_ID)).thenReturn(Optional.of(filing));
+        when(individualFilingRepository.save(any(PscIndividualFiling.class))).thenAnswer(
+            i -> PscIndividualFiling.builder(i.getArgument(0))
+                .build()); // copy of first argument
         when(clock.instant()).thenReturn(FIRST_INSTANT);
 
         mockMvc.perform(patch(URL_PSC_INDIVIDUAL_RESOURCE, TRANS_ID, FILING_ID).content(body)
-                        .contentType(APPLICATION_JSON_MERGE_PATCH)
-                        .requestAttr("transaction", transaction)
-                        .headers(httpHeaders))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id", is(FILING_ID)))
-                .andExpect(jsonPath("$.ceased_on").doesNotExist())
+                .contentType(APPLICATION_JSON_MERGE_PATCH)
+                .requestAttr("transaction", transaction)
+                .headers(httpHeaders))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id", is(FILING_ID)))
+            .andExpect(jsonPath("$.ceased_on").doesNotExist())
                 .andExpect(jsonPath("$.name_elements.forename", is("Forename")))
                 .andExpect(jsonPath("$.name_elements.other_forenames", is("Other Forenames")))
                 .andExpect(jsonPath("$.name_elements.title", is("Sir")))
@@ -267,29 +271,31 @@ class PscIndividualFilingControllerImplMergeIT extends BaseControllerIT {
     void updateFilingWhenFieldsAbsentThenTouchedButUnchanged() throws Exception {
         final var body = "{ }";
         final var filing = PscIndividualFiling.builder()
-                .id(FILING_ID)
-                .referenceEtag(ETAG)
-                .referencePscId(PSC_ID)
-                .ceasedOn(CEASED_ON_DATE)
-                .nameElements(nameElements)
-                .registerEntryDate(REGISTER_ENTRY_DATE)
-                .updatedAt(FIRST_INSTANT)
-                .build();
+            .id(FILING_ID)
+            .referenceEtag(ETAG)
+            .referencePscId(PSC_ID)
+            .ceasedOn(CEASED_ON_DATE)
+            .nameElements(nameElements)
+            .registerEntryDate(REGISTER_ENTRY_DATE)
+            .updatedAt(FIRST_INSTANT)
+            .links(links)
+            .build();
 
-        when(pscFilingService.get(FILING_ID)).thenReturn(Optional.of(filing));
-        when(pscFilingService.save(any(PscIndividualFiling.class))).thenAnswer(
-                i -> PscIndividualFiling.builder(i.getArgument(0))
-                        .build()); // copy of first argument
+        when(filingRepository.findById(FILING_ID)).thenReturn(Optional.of(filing));
+        when(individualFilingRepository.findById(FILING_ID)).thenReturn(Optional.of(filing));
+        when(individualFilingRepository.save(any(PscIndividualFiling.class))).thenAnswer(
+            i -> PscIndividualFiling.builder(i.getArgument(0))
+                .build()); // copy of first argument
         when(clock.instant()).thenReturn(SECOND_INSTANT);
 
         mockMvc.perform(patch(URL_PSC_INDIVIDUAL_RESOURCE, TRANS_ID, FILING_ID).content(body)
-                        .contentType(APPLICATION_JSON_MERGE_PATCH)
-                        .requestAttr("transaction", transaction)
-                        .headers(httpHeaders))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id", is(FILING_ID)))
-                .andExpect(jsonPath("$.reference_etag", is(ETAG)))
+                .contentType(APPLICATION_JSON_MERGE_PATCH)
+                .requestAttr("transaction", transaction)
+                .headers(httpHeaders))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id", is(FILING_ID)))
+            .andExpect(jsonPath("$.reference_etag", is(ETAG)))
                 .andExpect(jsonPath("$.reference_psc_id", is(PSC_ID)))
                 .andExpect(jsonPath("$.ceased_on", is("2022-09-13")))
                 .andExpect(jsonPath("$.name_elements.forename", is("Forename")))
@@ -304,28 +310,29 @@ class PscIndividualFilingControllerImplMergeIT extends BaseControllerIT {
     @DisplayName("Expect PATCH validation to return an error when validation fails")
     void updateFilingWhenDateInFuture() throws Exception {
         final var body = "{\n"
-                + " \"ceased_on\": \"2023-11-05\", \n"
-                + " \"register_entry_date\": \"2023-11-05\" \n"
-                + "}";
+            + " \"ceased_on\": \"2023-11-05\", \n"
+            + " \"register_entry_date\": \"2023-11-05\" \n"
+            + "}";
         final var filing = PscIndividualFiling.builder()
-                .id(FILING_ID)
-                .referenceEtag(ETAG)
-                .referencePscId(PSC_ID)
-                .registerEntryDate(REGISTER_ENTRY_DATE)
-                .links(links)
-                .build();
+            .id(FILING_ID)
+            .referenceEtag(ETAG)
+            .referencePscId(PSC_ID)
+            .registerEntryDate(REGISTER_ENTRY_DATE)
+            .links(links)
+            .build();
 
-        when(pscFilingService.get(FILING_ID)).thenReturn(Optional.of(filing));
+        when(filingRepository.findById(FILING_ID)).thenReturn(Optional.of(filing));
+        when(individualFilingRepository.findById(FILING_ID)).thenReturn(Optional.of(filing));
         when(clock.instant()).thenReturn(FIRST_INSTANT);
 
         final var expectedError = "must be a date in the past or in the present";
         final Map<String, String> expectedValues = Map.of("rejected", "2023-11-05");
 
         mockMvc.perform(patch(URL_PSC_INDIVIDUAL_RESOURCE, TRANS_ID, FILING_ID).content(body)
-                        .contentType(APPLICATION_JSON_MERGE_PATCH)
-                        .requestAttr("transaction", transaction)
-                        .headers(httpHeaders))
-                .andDo(print())
+                .contentType(APPLICATION_JSON_MERGE_PATCH)
+                .requestAttr("transaction", transaction)
+                .headers(httpHeaders))
+            .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors", hasSize(2)))
                 .andExpect(jsonPath("$.errors[*].error",
@@ -344,20 +351,21 @@ class PscIndividualFilingControllerImplMergeIT extends BaseControllerIT {
     @DisplayName("Expect PATCH validation error to omit class names")
     void updateFilingWhenDateInvalid() throws Exception {
         final var body = "{\n"
-                + " \"ceased_on\": \"2023-11-5\" \n"
-                + "}";
+            + " \"ceased_on\": \"2023-11-5\" \n"
+            + "}";
         final var filing = PscIndividualFiling.builder()
-                .id(FILING_ID)
-                .referenceEtag(ETAG)
-                .referencePscId(PSC_ID)
-                .registerEntryDate(REGISTER_ENTRY_DATE)
-                .links(links)
-                .build();
+            .id(FILING_ID)
+            .referenceEtag(ETAG)
+            .referencePscId(PSC_ID)
+            .registerEntryDate(REGISTER_ENTRY_DATE)
+            .links(links)
+            .build();
         final var expectedError = createExpectedValidationError(
-                "JSON parse error: Text '2023-11-5' could not be parsed at index 8", "$.ceased_on",
-                1, 14);
+            "JSON parse error: Text '2023-11-5' could not be parsed at index 8", "$.ceased_on",
+            1, 14);
 
-        when(pscFilingService.get(FILING_ID)).thenReturn(Optional.of(filing));
+        when(filingRepository.findById(FILING_ID)).thenReturn(Optional.of(filing));
+        when(individualFilingRepository.findById(FILING_ID)).thenReturn(Optional.of(filing));
         when(clock.instant()).thenReturn(FIRST_INSTANT);
 
         mockMvc.perform(patch(URL_PSC_INDIVIDUAL_RESOURCE, TRANS_ID, FILING_ID).content(body)
@@ -384,14 +392,37 @@ class PscIndividualFilingControllerImplMergeIT extends BaseControllerIT {
     @DisplayName("If the submission ID does not match then return a 404 Not Found response")
     void updateFilingWhenNotFoundThen404() throws Exception {
         final var body = "{ }";
-        when(pscFilingService.get(FILING_ID)).thenReturn(Optional.empty());
+        when(individualFilingRepository.findById(FILING_ID)).thenReturn(Optional.empty());
 
         mockMvc.perform(patch(URL_PSC_INDIVIDUAL_RESOURCE, TRANS_ID, FILING_ID).content(body)
-                        .contentType(APPLICATION_JSON_MERGE_PATCH)
-                        .requestAttr("transaction", transaction)
-                        .headers(httpHeaders))
-                .andDo(print())
-                .andExpect(status().isNotFound());
+                .contentType(APPLICATION_JSON_MERGE_PATCH)
+                .requestAttr("transaction", transaction)
+                .headers(httpHeaders))
+            .andDo(print())
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("If the request URI does not match the filing's 'self' link then return a 404 " +
+        "Not Found response")
+    void updateFilingWhenTransactionIdMismatchThen404() throws Exception {
+        final var body = "{ }";
+        final URI BAD_SELF_URI = URI.create("/path/to/other_or_bad");
+        final var links = new Links(BAD_SELF_URI, VALIDATION_URI);
+        final var filing = PscIndividualFiling.builder()
+            .id(FILING_ID)
+            .referenceEtag(ETAG)
+            .referencePscId(PSC_ID)
+            .registerEntryDate(REGISTER_ENTRY_DATE)
+            .links(links)
+            .build();
+
+        mockMvc.perform(patch(URL_PSC_INDIVIDUAL_RESOURCE, TRANS_ID, FILING_ID).content(body)
+                .contentType(APPLICATION_JSON_MERGE_PATCH)
+                .requestAttr("transaction", transaction)
+                .headers(httpHeaders))
+            .andDo(print())
+            .andExpect(status().isNotFound());
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/impl/PscWithIdentificationFilingControllerImplMergeIT.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/impl/PscWithIdentificationFilingControllerImplMergeIT.java
@@ -17,8 +17,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.net.URI;
 import java.time.Clock;
-import java.time.LocalDate;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -151,15 +149,8 @@ class PscWithIdentificationFilingControllerImplMergeIT extends BaseControllerIT 
             .links(links)
             .identification(identification)
             .build();
-        final var expectedIdentification =
-            Identification.builder(identification).countryRegistered("Replaced").build();
-        final var expectedFiling =
-            PscWithIdentificationFiling.builder(filing).updatedAt(SECOND_INSTANT).ceasedOn(
-                LocalDate.of(2022, 3, 3)).identification(
-                expectedIdentification).naturesOfControl(List.of("type4")).build();
 
-        when(filingRepository.findById(FILING_ID)).thenReturn(Optional.of(filing)).thenReturn(
-            Optional.of(expectedFiling));
+        when(filingRepository.findById(FILING_ID)).thenReturn(Optional.of(filing));
         when(withIdentificationFilingRepository.findById(FILING_ID)).thenReturn(
             Optional.of(filing));
         when(withIdentificationFilingRepository.save(
@@ -209,15 +200,8 @@ class PscWithIdentificationFilingControllerImplMergeIT extends BaseControllerIT 
             .registerEntryDate(REGISTER_ENTRY_DATE)
             .links(links)
             .build();
-        final var expectedIdentification =
-            Identification.builder().countryRegistered("Added").build();
-        final var expectedFiling = PscWithIdentificationFiling.builder(filing).updatedAt(
-            SECOND_INSTANT).name(CORPORATE_NAME).ceasedOn(
-            LocalDate.of(2022, 10, 5)).identification(expectedIdentification).naturesOfControl(
-            List.of("type1", "type2", "type3", "type4")).build();
 
-        when(filingRepository.findById(FILING_ID)).thenReturn(Optional.of(filing)).thenReturn(
-            Optional.of(expectedFiling));
+        when(filingRepository.findById(FILING_ID)).thenReturn(Optional.of(filing));
         when(withIdentificationFilingRepository.findById(FILING_ID)).thenReturn(
             Optional.of(filing));
         when(withIdentificationFilingRepository.save(
@@ -273,14 +257,8 @@ class PscWithIdentificationFilingControllerImplMergeIT extends BaseControllerIT 
             .links(links)
             .registerEntryDate(REGISTER_ENTRY_DATE)
             .build();
-        final var expectedIdentification =
-            Identification.builder(identification).countryRegistered(null).build();
-        final var expectedFiling = PscWithIdentificationFiling.builder(filing).updatedAt(
-            SECOND_INSTANT).name(null).ceasedOn(null).identification(
-            expectedIdentification).naturesOfControl(Collections.emptyList()).build();
 
-        when(filingRepository.findById(FILING_ID)).thenReturn(Optional.of(filing)).thenReturn(
-            Optional.of(expectedFiling));
+        when(filingRepository.findById(FILING_ID)).thenReturn(Optional.of(filing));
         when(withIdentificationFilingRepository.findById(FILING_ID)).thenReturn(
             Optional.of(filing));
         when(withIdentificationFilingRepository.save(
@@ -324,11 +302,8 @@ class PscWithIdentificationFilingControllerImplMergeIT extends BaseControllerIT 
             .updatedAt(FIRST_INSTANT)
             .links(links)
             .build();
-        final var expectedFiling = PscWithIdentificationFiling.builder(filing).updatedAt(
-            SECOND_INSTANT).build();
 
-        when(filingRepository.findById(FILING_ID)).thenReturn(Optional.of(filing)).thenReturn(
-            Optional.of(expectedFiling));
+        when(filingRepository.findById(FILING_ID)).thenReturn(Optional.of(filing));
         when(withIdentificationFilingRepository.findById(FILING_ID)).thenReturn(
             Optional.of(filing));
         when(withIdentificationFilingRepository.save(


### PR DESCRIPTION
Check filing's 'self' link URI matches that of the HTTP request. This will check the following URI path components are correct:
- Transaction ID
- Filing ID
- PSC type