### PR TITLE
Create Dapperdox API specifications for psc-filing-api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ bin/
 .DS_Store
 ._*
 Footer
+/.history/

--- a/docs/psc-filing-api.json
+++ b/docs/psc-filing-api.json
@@ -6,7 +6,7 @@
   ],
   "info": {
     "title": "PSC Filing API (Private)",
-    "version": "0.7",
+    "version": "0.8",
     "description": "An API that allows clients to submit PSC filings. Currently for PSC07 (Cease a PSC) only."
   },
   "host": "api.chs.local:4001",
@@ -189,7 +189,7 @@
     },
     "/transactions/{transactionId}/persons-with-significant-control/{filingResourceId}/validation_status": {
       "get": {
-        "summary": "Check this Open filing resource for completeness",
+        "summary": "Check this Open PSC filing resource for completeness",
         "description": "Check the validity and completeness of an Open PSC filing resource. Primarily for use by the Transaction Service when requested to close the filing resource transaction.",
         "produces": [
           "application/json"

--- a/docs/psc-filing-api.json
+++ b/docs/psc-filing-api.json
@@ -25,7 +25,7 @@
   "tags": [
     {
       "name": "pscFiling",
-      "description": "PSC filing"
+      "description": "Persons with Significant Control"
     }
   ],
   "paths": {

--- a/docs/psc-filing-api.json
+++ b/docs/psc-filing-api.json
@@ -6,7 +6,7 @@
   ],
   "info": {
     "title": "PSC Filing API (Private)",
-    "version": "0.6",
+    "version": "0.7",
     "description": "An API that allows clients to submit PSC filings. Currently for PSC07 (Cease a PSC) only."
   },
   "host": "api.chs.local:4001",
@@ -31,8 +31,8 @@
   "paths": {
     "/transactions/{transactionId}/persons-with-significant-control/{pscType}": {
       "post": {
-        "summary": "Create a PSC filing resource",
-        "description": "Create a PSC filing of the specified type.",
+        "summary": "Create an Open PSC filing resource",
+        "description": "Create an Open PSC filing of the specified type. Requires an Open transaction. The filing becomes Closed when its associated transaction is closed.",
         "consumes": [
           "application/json"
         ],
@@ -58,7 +58,7 @@
             },
             "headers": {
               "Location": {
-                "description": "The URI of the newly created filing resource.",
+                "description": "The URI of the newly created resource.",
                 "type": "string",
                 "format": "uri"
               }
@@ -71,13 +71,16 @@
             "$ref": "#/responses/Unauthorized"
           },
           "403": {
-            "$ref": "#/responses/Forbidden"
+            "$ref": "#/responses/ForbiddenClosed"
           },
           "404": {
             "$ref": "#/responses/NotCreated"
           },
           "409": {
             "$ref": "#/responses/Conflict"
+          },
+          "415": {
+            "$ref": "#/responses/MediaTypeUnsupported"
           },
           "500": {
             "$ref": "#/responses/InternalServerError"
@@ -87,13 +90,13 @@
           "pscFiling"
         ],
         "operationId": "createFiling",
-        "x-operationName": "create filing"
+        "x-operationName": "create"
       }
     },
     "/transactions/{transactionId}/persons-with-significant-control/{pscType}/{filingResourceId}": {
       "get": {
-        "summary": "Get this PSC filing resource details",
-        "description": "Get this PSC filing resource details.",
+        "summary": "Get this Open PSC filing resource details",
+        "description": "The filing becomes Closed when its associated transaction is closed.",
         "produces": [
           "application/json"
         ],
@@ -112,9 +115,6 @@
           "200": {
             "$ref": "#/responses/FilingFound"
           },
-          "400": {
-            "$ref": "#/responses/CreateFilingBadRequest"
-          },
           "401": {
             "$ref": "#/responses/Unauthorized"
           },
@@ -129,11 +129,11 @@
           "pscFiling"
         ],
         "operationId": "getFiling",
-        "x-operationName": "get filing"
+        "x-operationName": "get"
       },
       "patch": {
-        "summary": "Update this PSC filing resource",
-        "description": "Update writable properties of a filing resource. See [RFC7396](https://www.rfc-editor.org/rfc/rfc7396) for details, including how to add, replace, and remove properties.",
+        "summary": "Update this Open PSC filing resource",
+        "description": "Update writable properties of an Open filing resource. See [RFC7396](https://www.rfc-editor.org/rfc/rfc7396) for details, including how to add, replace, and remove properties.",
         "consumes": [
           "application/merge-patch+json"
         ],
@@ -165,13 +165,16 @@
             "$ref": "#/responses/Unauthorized"
           },
           "403": {
-            "$ref": "#/responses/Forbidden"
+            "$ref": "#/responses/ForbiddenClosed"
           },
           "404": {
             "$ref": "#/responses/FilingNotFound"
           },
           "409": {
             "$ref": "#/responses/Conflict"
+          },
+          "415": {
+            "$ref": "#/responses/MediaTypeUnsupported"
           },
           "500": {
             "$ref": "#/responses/InternalServerError"
@@ -181,13 +184,13 @@
           "pscFiling"
         ],
         "operationId": "updateFiling",
-        "x-operationName": "update filing"
+        "x-operationName": "update"
       }
     },
     "/transactions/{transactionId}/persons-with-significant-control/{filingResourceId}/validation_status": {
       "get": {
-        "summary": "Check this filing resource for completeness",
-        "description": "Check the validity and completeness of a PSC filing. Primarily for use by the Transaction Service when requested to close the filing resource transaction.",
+        "summary": "Check this Open filing resource for completeness",
+        "description": "Check the validity and completeness of an Open PSC filing resource. Primarily for use by the Transaction Service when requested to close the filing resource transaction.",
         "produces": [
           "application/json"
         ],
@@ -220,13 +223,13 @@
           "pscFiling"
         ],
         "operationId": "validateFiling",
-        "x-operationName": "validate filing"
+        "x-operationName": "validate"
       }
     },
     "/private/transactions/{transactionId}/persons-with-significant-control/{pscType}/{filingResourceId}/filings": {
       "get": {
-        "summary": "Get CHIPS-compatible details of this filing resource",
-        "description": "Get the CHIPS-compatible details of this filing resource. For internal use by the filing resource handler service.",
+        "summary": "Get the Closed PSC filing details",
+        "description": "Get the CHIPS-compatible details of this Closed PSC filing resource. For internal use by the filing resource handler service.\n\n### NOTE\nThe transaction associated with this filing **should** have been Closed before making this request.",
         "produces": [
           "application/json"
         ],
@@ -254,7 +257,7 @@
             "$ref": "#/responses/Unauthorized"
           },
           "403": {
-            "description": "Forbidden \n* The authorization identity type must equal '`key`' and \n* The authenticated user account must have internal user privileges and\n* The request must have an API key that has internal application privileges."
+            "$ref": "#/responses/ForbiddenOpen"
           },
           "404": {
             "$ref": "#/responses/FilingNotFound"
@@ -263,14 +266,14 @@
             "$ref": "#/responses/Conflict"
           },
           "500": {
-            "description": "The request could not be fulfilled because:\n* The filing resource transaction is not Closed or\n* an internal error."
+            "description": "Possible causes include:\n\n* The transaction with ID `transactionId` **must** be in an Closed state\n* An internal error occurred"
           }
         },
         "tags": [
           "pscFiling"
         ],
-        "operationId": "getFilingForChips",
-        "x-operationName": "get filing for CHIPS"
+        "operationId": "getFilingData",
+        "x-operationName": "get closed"
       }
     }
   },
@@ -348,8 +351,11 @@
         "type": "array"
       }
     },
-    "Forbidden": {
-      "description": "The transaction with ID `transactionId` is not in an open state, or the operation is otherwise not allowed."
+    "ForbiddenOpen": {
+      "description": "Possible causes include:\n\n* The authorization identity type **must** equal '`key`'\n* The authenticated user account **must** have internal user privileges\n* The request authorization **must** be an API key that has internal application privileges.\n"
+    },
+    "ForbiddenClosed": {
+      "description": "Possible causes include:\n\n* The transaction with ID `transactionId` **must** be in an Open state"
     },
     "InternalServerError": {
       "description": "The request could not be fulfilled because of an internal error.",
@@ -362,6 +368,21 @@
     },
     "NotFound": {
       "description": "A filing with the specified combination of `transactionId`, `filingResourceId` and `pscType` could not be found."
+    },
+    "MediaTypeUnsupported": {
+      "description": "The content type of the request is not acceptable. Refer to the `Accept-Patch` or `Accept-Post` header for the acceptable content type.",
+      "headers": {
+        "Accept-Patch": {
+          "description": "`application/merge-patch+json`",
+          "type": "string",
+          "format": "uri"
+        },
+        "Accept-Post": {
+          "description": "`application/json`",
+          "type": "string",
+          "format": "uri"
+        }
+      }
     },
     "PscFilingUpdated": {
       "description": "For convenience the response body provides the details of the updated filing resource.",

--- a/docs/spec-v2.0.json
+++ b/docs/spec-v2.0.json
@@ -2,8 +2,8 @@
   "swagger": "2.0",
   "info": {
     "title": "PSC Filing API (Private)",
-    "version": "0.1",
-    "description": "Private specification for receiving PSC filings (PSC07 only) by third party software filers and CHS internal users. \n\n__Note__ this includes private endpoints for CHS internal services."
+    "version": "0.2",
+    "description": "Private specification for the PSC Filings service (currently for PSC07 [Cease a PSC] only). Includes:\n * Public paths for use by third party software filers and \n* Private paths for CHS internal users.\n---\n ### NOTE\nModels include data properties required for any of PSC01 to PSC09, however most are currently unused.\n\nPSC07 requires only\n* `ceased_on`\n* `register_entry-date`\n* `reference_psc_id`\n* `reference_etag`"
   },
   "host": "api.chs.local:4001",
   "basePath": "/",
@@ -12,29 +12,29 @@
   ],
   "security": [
     {
-      "ERIC oauth2": []
+      "OAuth2-ERIC": []
     }
   ],
   "tags": [
     {
-      "name": "Filing Data",
-      "description": "For use by the CHS filing resource handler service."
+      "name": "PSC Filing",
+      "description": "For creating, updating, and retrieving PSC filings"
     },
     {
-      "name": "Private",
-      "description": "For internal use only"
+      "name": "Filing Data",
+      "description": "For use by the CHS filing resource handler service."
     },
     {
       "name": "Validation Status",
       "description": "For public use and for the CHS transaction service when attempting to close a transaction."
     },
     {
-      "name": "Public",
+      "name": "Public Access",
       "description": "For public use"
     },
     {
-      "name": "PSC Filing",
-      "description": "For creating, updating, and retrieving PSC filings"
+      "name": "Private Access",
+      "description": "For internal use only"
     }
   ],
   "paths": {
@@ -45,7 +45,7 @@
         ],
         "security": [
           {
-            "ERIC API Key": []
+            "API-Key-ERIC": []
           }
         ],
         "parameters": [
@@ -96,7 +96,7 @@
         },
         "tags": [
           "Filing Data",
-          "Private"
+          "Private Access"
         ],
         "operationId": "getFilingsData"
       }
@@ -145,12 +145,12 @@
         },
         "tags": [
           "Validation Status",
-          "Public"
+          "Public Access"
         ],
         "operationId": "validate"
       }
     },
-    "/transactions/{transactionId}/persons-with-significant-control/{pscType}": {
+    "/transactions/{transactionId}/persons-with-significant-control/individual": {
       "post": {
         "consumes": [
           "application/json"
@@ -163,25 +163,20 @@
             "$ref": "#/parameters/transactionId"
           },
           {
-            "$ref": "#/parameters/pscType"
-          },
-          {
             "in": "body",
             "name": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/PscIndividualDto"
+              "$ref": "#/definitions/PscIndividual"
             }
           }
         ],
         "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {}
+          "201": {
+            "$ref": "#/responses/PscIndividualFilingCreated"
           },
           "400": {
-            "description": "Bad Request",
-            "schema": {}
+            "$ref": "#/responses/CreateFilingBadRequest"
           },
           "401": {
             "$ref": "#/responses/Unauthorized"
@@ -210,9 +205,129 @@
         },
         "tags": [
           "PSC Filing",
-          "Public"
+          "Public Access"
         ],
-        "operationId": "createFiling_1"
+        "operationId": "createIndividualPscFiling"
+      }
+    },
+    "/transactions/{transactionId}/persons-with-significant-control/corporate-entity": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/transactionId"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PscWithIdentification"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "$ref": "#/responses/PscCorporateEntityFilingCreated"
+          },
+          "400": {
+            "$ref": "#/responses/CreateFilingBadRequest"
+          },
+          "401": {
+            "$ref": "#/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/responses/Forbidden"
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/ApiErrors"
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "schema": {
+              "$ref": "#/definitions/ApiErrors"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/ApiErrors"
+            }
+          }
+        },
+        "tags": [
+          "PSC Filing",
+          "Public Access"
+        ],
+        "operationId": "createCorporateEntityPscFiling"
+      }
+    },
+    "/transactions/{transactionId}/persons-with-significant-control/legal-person": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/transactionId"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PscWithIdentification"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "$ref": "#/responses/PscLegalPersonFilingCreated"
+          },
+          "400": {
+            "$ref": "#/responses/CreateFilingBadRequest"
+          },
+          "401": {
+            "$ref": "#/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/responses/Forbidden"
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/ApiErrors"
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "schema": {
+              "$ref": "#/definitions/ApiErrors"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/ApiErrors"
+            }
+          }
+        },
+        "tags": [
+          "PSC Filing",
+          "Public Access"
+        ],
+        "operationId": "createLegalPersonPscFiling"
       }
     },
     "/transactions/{transactionId}/persons-with-significant-control/{pscType}/{filingResourceId}": {
@@ -256,7 +371,7 @@
         },
         "tags": [
           "PSC Filing",
-          "Public"
+          "Public Access"
         ],
         "operationId": "getFilingForReview"
       },
@@ -322,7 +437,7 @@
         },
         "tags": [
           "PSC Filing",
-          "Public"
+          "Public Access"
         ],
         "operationId": "updateFiling"
       }
@@ -360,6 +475,68 @@
     }
   },
   "responses": {
+    "PscIndividualFilingCreated": {
+      "description": "The filing resource was created.",
+      "schema": {
+        "$ref": "#/definitions/PscIndividualFiling"
+      },
+      "examples": {
+        "application/json": {
+          "ceased_on": "2022-08-29",
+          "links": {
+            "self": "/transactions/021576-444716-850996/persons-with-significant-control/individual/6470946f9f4c3f6c1ed25a19",
+            "validation_status": "/transactions/021576-444716-850996/persons-with-significant-control/6470946f9f4c3f6c1ed25a19/validation_status"
+          },
+          "reference_etag": "8cb9d4c9ba82059ff01ed638105bc41c1bc4db40",
+          "reference_psc_id": "1kdaTltWeaP1EB70SSD9SLmiK5Y",
+          "register_entry_date": "2022-10-15",
+          "id": "6470946f9f4c3f6c1ed25a19",
+          "created_at": "2023-05-26T11:13:51.787Z",
+          "updated_at": "2023-05-26T11:13:51.787Z"
+        }
+      }
+    },
+    "PscCorporateEntityFilingCreated": {
+      "description": "The filing resource was created.",
+      "schema": {
+        "$ref": "#/definitions/PscWithIdentificationFiling"
+      },
+      "examples": {
+        "application/json": {
+          "ceased_on": "2023-04-19",
+          "links": {
+            "self": "/transactions/098781-975316-819849/persons-with-significant-control/corporate-entity/64410d94aa51447dcf469570",
+            "validation_status": "/transactions/098781-975316-819849/persons-with-significant-control/64410d94aa51447dcf469570/validation_status"
+          },
+          "reference_etag": "4e5fda8b2b6dba10862965ee34d80915d7b48266",
+          "reference_psc_id": "fhhMkjhxbWGc0juOZvDhNcbFn8o",
+          "register_entry_date": "2023-04-19",
+          "id": "64410d94aa51447dcf469570",
+          "created_at": "2023-04-20T10:01:56.129Z",
+          "updated_at": "2023-04-20T10:01:56.129Z"
+        }
+      }
+    },
+    "PscLegalPersonFilingCreated": {
+      "description": "The filing resource was created.",
+      "schema": {
+        "$ref": "#/definitions/PscWithIdentificationFiling"
+      },
+      "examples": {
+        "application/json": {
+          "links": {
+            "self": "/transactions/116642-036916-819881/persons-with-significant-control/legal-person/64411a2faa51447dcf469693",
+            "validation_status": "/transactions/116642-036916-819881/persons-with-significant-control/64411a2faa51447dcf469693/validation_status"
+          },
+          "reference_etag": "b1786d54fd49e0cd21a3bf402819370f35d24ad1",
+          "reference_psc_id": "OTk2OTA1NDg4OExJSzBNUjFR",
+          "register_entry_date": "2023-04-19T23:00:00.000Z",
+          "id": "64411a2faa51447dcf469693",
+          "created_at": "2023-04-20T10:55:43.695Z",
+          "updated_at": "2023-04-20T10:55:43.695Z"
+        }
+      }
+    },
     "FilingFound": {
       "description": "The filing resource was found.",
       "schema": {
@@ -425,515 +602,802 @@
           "type": "ch:service"
         }
       }
+    },
+    "CreateFilingBadRequest": {
+      "description": "The request to create a filing resource contained bad data.",
+      "examples": {
+        "application/json": {
+          "errors": [
+            {
+              "error": "{rejected-value} must be a date in the past or in the present",
+              "error_values": {
+                "rejected-value": "3000-08-29"
+              },
+              "location": "$.ceased_on",
+              "location_type": "json-path",
+              "type": "ch:validation"
+            }
+          ]
+        }
+      }
     }
-},
-"securityDefinitions": {
-"ERIC oauth2": {
-"type": "oauth2",
-"flow": "accessCode",
-"authorizationUrl": "http://account.chs.local/oauth2/authorise",
-"tokenUrl": "http://account.chs.local/oauth2/token",
-"scopes": {
-"https://account.companieshouse.gov.uk/user/profile.read": "User profile read permission",
-"https://api.company-information.service.gov.uk/company/{company_number}/persons-with-significant-control.delete": "Grants permissions to remove a PSC from this company"
-}
-},
-"ERIC API Key": {
-"type": "apiKey",
-"name": "api_key",
-"in": "header"
-}
-},
-"definitions": {
-"Address": {
-"properties": {
-"addressLine1": {
-"type": "string"
-},
-"addressLine2": {
-"type": "string"
-},
-"careOf": {
-"type": "string"
-},
-"country": {
-"type": "string"
-},
-"locality": {
-"type": "string"
-},
-"poBox": {
-"type": "string"
-},
-"postalCode": {
-"type": "string"
-},
-"premises": {
-"type": "string"
-},
-"region": {
-"type": "string"
-}
-},
-"required": [
-"addressLine1"
-],
-"type": "object"
-},
-"AddressDto": {
-"properties": {
-"address_line_1": {
-"type": "string"
-},
-"address_line_2": {
-"type": "string"
-},
-"careOf": {
-"type": "string"
-},
-"country": {
-"type": "string"
-},
-"locality": {
-"type": "string"
-},
-"poBox": {
-"type": "string"
-},
-"postalCode": {
-"type": "string"
-},
-"premises": {
-"type": "string"
-},
-"region": {
-"type": "string"
-}
-},
-"type": "object"
-},
-"ApiError": {
-"properties": {
-"error": {
-"type": "string"
-},
-"errorValues": {
-"additionalProperties": {
-"type": "string"
-},
-"type": "object"
-},
-"location": {
-"type": "string"
-},
-"locationType": {
-"type": "string"
-},
-"type": {
-"type": "string"
-}
-},
-"type": "object"
-},
-"FilingNotFoundError": {
-"type": "object",
-"properties": {
-}
-},
-"ApiErrors": {
-"properties": {
-"errors": {
-"items": {
-"$ref": "#/definitions/ApiError"
-},
-"type": "array",
-"uniqueItems": true
-}
-},
-"type": "object"
-},
-"Date3Tuple": {
-"properties": {
-"day": {
-"format": "int32",
-"type": "integer"
-},
-"month": {
-"format": "int32",
-"type": "integer"
-},
-"year": {
-"format": "int32",
-"type": "integer"
-}
-},
-"type": "object"
-},
-"Date3TupleDto": {
-"properties": {
-"day": {
-"format": "int32",
-"type": "integer"
-},
-"month": {
-"format": "int32",
-"type": "integer"
-},
-"year": {
-"format": "int32",
-"type": "integer"
-}
-},
-"type": "object"
-},
-"FilingApi": {
-"properties": {
-"data": {
-"additionalProperties": {
-"type": "object"
-},
-"type": "object"
-},
-"description": {
-"type": "string"
-},
-"description_identifier": {
-"type": "string"
-},
-"description_values": {
-"additionalProperties": {
-"type": "string"
-},
-"type": "object"
-},
-"kind": {
-"type": "string"
-}
-},
-"type": "object"
-},
-"Identification": {
-"properties": {
-"countryRegistered": {
-"type": "string"
-},
-"legalAuthority": {
-"type": "string"
-},
-"legalForm": {
-"type": "string"
-},
-"placeRegistered": {
-"type": "string"
-},
-"registrationNumber": {
-"type": "string"
-}
-},
-"type": "object"
-},
-"Link": {
-"properties": {
-"href": {
-"type": "string"
-},
-"templated": {
-"type": "boolean"
-}
-},
-"type": "object"
-},
-"Links": {
-"properties": {
-"self": {
-"format": "uri",
-"type": "string"
-},
-"validationStatus": {
-"format": "uri",
-"type": "string"
-}
-},
-"type": "object"
-},
-"NameElements": {
-"properties": {
-"forename": {
-"type": "string"
-},
-"otherForenames": {
-"type": "string"
-},
-"other_forenames": {
-"type": "string"
-},
-"surname": {
-"type": "string"
-},
-"title": {
-"type": "string"
-}
-},
-"type": "object"
-},
-"NameElementsDto": {
-"properties": {
-"forename": {
-"type": "string"
-},
-"otherForenames": {
-"type": "string"
-},
-"other_forenames": {
-"type": "string"
-},
-"surname": {
-"type": "string"
-},
-"title": {
-"type": "string"
-}
-},
-"type": "object"
-},
-"PscIndividualDto": {
-"properties": {
-"address": {
-"$ref": "#/definitions/AddressDto"
-},
-"addressSameAsRegisteredOfficeAddress": {
-"type": "boolean"
-},
-"ceasedOn": {
-"format": "date",
-"type": "string"
-},
-"countryOfResidence": {
-"type": "string"
-},
-"dateOfBirth": {
-"$ref": "#/definitions/Date3TupleDto"
-},
-"nameElements": {
-"$ref": "#/definitions/NameElementsDto"
-},
-"nationality": {
-"type": "string"
-},
-"naturesOfControl": {
-"items": {
-"type": "string"
-},
-"type": "array"
-},
-"notifiedOn": {
-"format": "date",
-"type": "string"
-},
-"referenceEtag": {
-"type": "string"
-},
-"referencePscId": {
-"type": "string"
-},
-"registerEntryDate": {
-"format": "date",
-"type": "string"
-},
-"residentialAddress": {
-"$ref": "#/definitions/AddressDto"
-},
-"residentialAddressSameAsCorrespondenceAddress": {
-"type": "boolean"
-}
-},
-"type": "object"
-},
-"PscIndividualFiling": {
-"properties": {
-"address": {
-"$ref": "#/definitions/Address"
-},
-"addressSameAsRegisteredOfficeAddress": {
-"type": "boolean"
-},
-"ceasedOn": {
-"format": "date",
-"type": "string"
-},
-"countryOfResidence": {
-"type": "string"
-},
-"created_at": {
-"format": "date-time",
-"readOnly": true,
-"type": "string"
-},
-"dateOfBirth": {
-"$ref": "#/definitions/Date3Tuple"
-},
-"etag": {
-"type": "string"
-},
-"id": {
-"readOnly": true,
-"type": "string"
-},
-"kind": {
-"type": "string"
-},
-"links": {
-"$ref": "#/definitions/Links"
-},
-"nameElements": {
-"$ref": "#/definitions/NameElements"
-},
-"nationality": {
-"type": "string"
-},
-"naturesOfControl": {
-"items": {
-"type": "string"
-},
-"type": "array"
-},
-"notifiedOn": {
-"format": "date",
-"type": "string"
-},
-"referenceEtag": {
-"type": "string"
-},
-"referencePscId": {
-"type": "string"
-},
-"registerEntryDate": {
-"format": "date",
-"type": "string"
-},
-"residentialAddress": {
-"$ref": "#/definitions/Address"
-},
-"residentialAddressSameAsCorrespondenceAddress": {
-"type": "boolean"
-},
-"statementActionDate": {
-"format": "date",
-"type": "string"
-},
-"statementType": {
-"type": "string"
-},
-"updated_at": {
-"format": "date-time",
-"readOnly": true,
-"type": "string"
-}
-},
-"type": "object"
-},
-"PscWithIdentificationFiling": {
-"properties": {
-"address": {
-"$ref": "#/definitions/Address"
-},
-"addressSameAsRegisteredOfficeAddress": {
-"type": "boolean"
-},
-"ceasedOn": {
-"format": "date",
-"type": "string"
-},
-"created_at": {
-"format": "date-time",
-"readOnly": true,
-"type": "string"
-},
-"etag": {
-"type": "string"
-},
-"id": {
-"readOnly": true,
-"type": "string"
-},
-"identification": {
-"$ref": "#/definitions/Identification"
-},
-"kind": {
-"type": "string"
-},
-"links": {
-"$ref": "#/definitions/Links"
-},
-"name": {
-"type": "string"
-},
-"naturesOfControl": {
-"items": {
-"type": "string"
-},
-"type": "array"
-},
-"notifiedOn": {
-"format": "date",
-"type": "string"
-},
-"referenceEtag": {
-"type": "string"
-},
-"referencePscId": {
-"type": "string"
-},
-"registerEntryDate": {
-"format": "date",
-"type": "string"
-},
-"statementActionDate": {
-"format": "date",
-"type": "string"
-},
-"statementType": {
-"type": "string"
-},
-"updated_at": {
-"format": "date-time",
-"readOnly": true,
-"type": "string"
-}
-},
-"type": "object"
-},
-"ValidationStatusError": {
-"properties": {
-"error": {
-"type": "string"
-},
-"location": {
-"type": "string"
-},
-"location_type": {
-"type": "string"
-},
-"type": {
-"type": "string"
-}
-},
-"type": "object"
-},
-"ValidationStatusResponse": {
-"properties": {
-"errors": {
-"items": {
-"$ref": "#/definitions/ValidationStatusError"
-},
-"type": "array"
-},
-"is_valid": {
-"type": "boolean"
-}
-},
-"type": "object"
-}
-},
-"x-components": {}
+  },
+  "securityDefinitions": {
+    "OAuth2-ERIC": {
+      "type": "oauth2",
+      "flow": "accessCode",
+      "authorizationUrl": "http://account.chs.local/oauth2/authorise",
+      "tokenUrl": "http://account.chs.local/oauth2/token",
+      "scopes": {
+        "https://account.companieshouse.gov.uk/user/profile.read": "Grants permission to read CHS User profile.",
+        "https://api.company-information.service.gov.uk/company/{company_number}/persons-with-significant-control.delete": "Grants permission to cease a PSC belonging to this company."
+      }
+    },
+    "API-Key-ERIC": {
+      "type": "apiKey",
+      "name": "api_key",
+      "in": "header"
+    }
+  },
+  "definitions": {
+    "Address": {
+      "properties": {
+        "address_line_1": {
+          "type": "string"
+        },
+        "address_line_2": {
+          "type": "string"
+        },
+        "care_of": {
+          "type": "string"
+        },
+        "country": {
+          "type": "string"
+        },
+        "locality": {
+          "type": "string"
+        },
+        "po_box": {
+          "type": "string"
+        },
+        "postal_code": {
+          "type": "string"
+        },
+        "premises": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ApiError": {
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "error_values": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        },
+        "location_type": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "FilingNotFoundError": {
+      "type": "object",
+      "properties": {
+      }
+    },
+    "ApiErrors": {
+      "properties": {
+        "errors": {
+          "items": {
+            "$ref": "#/definitions/ApiError"
+          },
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
+    },
+    "Date": {
+      "properties": {
+        "day": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "month": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "year": {
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "FilingApi": {
+      "properties": {
+        "data": {
+          "additionalProperties": {
+            "type": "object"
+          },
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "description_identifier": {
+          "type": "string"
+        },
+        "description_values": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Identification": {
+      "properties": {
+        "country_registered": {
+          "type": "string"
+        },
+        "legal_authority": {
+          "type": "string"
+        },
+        "legal_form": {
+          "type": "string"
+        },
+        "place_registered": {
+          "type": "string"
+        },
+        "registration_number": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Links": {
+      "properties": {
+        "self": {
+          "format": "uri",
+          "type": "string"
+        },
+        "validation_status": {
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "NameElements": {
+      "properties": {
+        "forename": {
+          "type": "string"
+        },
+        "other_forenames": {
+          "type": "string"
+        },
+        "surname": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "PscIndividual": {
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/Address"
+        },
+        "address_same_as_registered_office_address": {
+          "type": "boolean"
+        },
+        "ceased_on": {
+          "format": "date",
+          "type": "string"
+        },
+        "country_of_residence": {
+          "type": "string"
+        },
+        "date_of_birth": {
+          "$ref": "#/definitions/Date"
+        },
+        "name_elements": {
+          "$ref": "#/definitions/NameElements"
+        },
+        "nationality": {
+          "type": "string"
+        },
+        "natures_of_control": {
+          "items": {
+            "type": "string",
+            "enum": [
+              "ownership-of-shares-25-to-50-percent",
+              "ownership-of-shares-50-to-75-percent",
+              "ownership-of-shares-75-to-100-percent",
+              "ownership-of-shares-25-to-50-percent-as-trust",
+              "ownership-of-shares-50-to-75-percent-as-trust",
+              "ownership-of-shares-75-to-100-percent-as-trust",
+              "ownership-of-shares-25-to-50-percent-as-firm",
+              "ownership-of-shares-50-to-75-percent-as-firm",
+              "ownership-of-shares-75-to-100-percent-as-firm",
+              "ownership-of-shares-more-than-25-percent-registered-overseas-entity",
+              "ownership-of-shares-more-than-25-percent-as-trust-registered-overseas-entity",
+              "ownership-of-shares-more-than-25-percent-as-firm-registered-overseas-entity",
+              "voting-rights-25-to-50-percent",
+              "voting-rights-50-to-75-percent",
+              "voting-rights-75-to-100-percent",
+              "voting-rights-25-to-50-percent-as-trust",
+              "voting-rights-50-to-75-percent-as-trust",
+              "voting-rights-75-to-100-percent-as-trust",
+              "voting-rights-25-to-50-percent-as-firm",
+              "voting-rights-50-to-75-percent-as-firm",
+              "voting-rights-75-to-100-percent-as-firm",
+              "voting-rights-more-than-25-percent-registered-overseas-entity",
+              "voting-rights-more-than-25-percent-as-trust-registered-overseas-entity",
+              "voting-rights-more-than-25-percent-as-firm-registered-overseas-entity",
+              "right-to-appoint-and-remove-directors",
+              "right-to-appoint-and-remove-directors-as-trust",
+              "right-to-appoint-and-remove-directors-as-firm",
+              "significant-influence-or-control",
+              "significant-influence-or-control-as-trust",
+              "significant-influence-or-control-as-firm",
+              "right-to-share-surplus-assets-25-to-50-percent-limited-liability-partnership",
+              "right-to-share-surplus-assets-50-to-75-percent-limited-liability-partnership",
+              "right-to-share-surplus-assets-75-to-100-percent-limited-liability-partnership",
+              "right-to-share-surplus-assets-25-to-50-percent-as-trust-limited-liability-partnership",
+              "right-to-share-surplus-assets-50-to-75-percent-as-trust-limited-liability-partnership",
+              "right-to-share-surplus-assets-75-to-100-percent-as-trust-limited-liability-partnership",
+              "right-to-share-surplus-assets-25-to-50-percent-as-firm-limited-liability-partnership",
+              "right-to-share-surplus-assets-50-to-75-percent-as-firm-limited-liability-partnership",
+              "right-to-share-surplus-assets-75-to-100-percent-as-firm-limited-liability-partnership",
+              "voting-rights-25-to-50-percent-limited-liability-partnership",
+              "voting-rights-50-to-75-percent-limited-liability-partnership",
+              "voting-rights-75-to-100-percent-limited-liability-partnership",
+              "voting-rights-25-to-50-percent-as-trust-limited-liability-partnership",
+              "voting-rights-50-to-75-percent-as-trust-limited-liability-partnership",
+              "voting-rights-75-to-100-percent-as-trust-limited-liability-partnership",
+              "voting-rights-25-to-50-percent-as-firm-limited-liability-partnership",
+              "voting-rights-50-to-75-percent-as-firm-limited-liability-partnership",
+              "voting-rights-75-to-100-percent-as-firm-limited-liability-partnership",
+              "right-to-appoint-and-remove-members-limited-liability-partnership",
+              "right-to-appoint-and-remove-members-as-trust-limited-liability-partnership",
+              "right-to-appoint-and-remove-members-as-firm-limited-liability-partnership",
+              "significant-influence-or-control-limited-liability-partnership",
+              "significant-influence-or-control-as-trust-limited-liability-partnership",
+              "significant-influence-or-control-as-firm-limited-liability-partnership",
+              "significant-influence-or-control-registered-overseas-entity",
+              "significant-influence-or-control-as-trust-registered-overseas-entity",
+              "significant-influence-or-control-as-firm-registered-overseas-entity",
+              "part-right-to-share-surplus-assets-25-to-50-percent",
+              "part-right-to-share-surplus-assets-50-to-75-percent",
+              "part-right-to-share-surplus-assets-75-to-100-percent",
+              "part-right-to-share-surplus-assets-25-to-50-percent-as-trust",
+              "part-right-to-share-surplus-assets-50-to-75-percent-as-trust",
+              "part-right-to-share-surplus-assets-75-to-100-percent-as-trust",
+              "part-right-to-share-surplus-assets-25-to-50-percent-as-firm",
+              "part-right-to-share-surplus-assets-50-to-75-percent-as-firm",
+              "part-right-to-share-surplus-assets-75-to-100-percent-as-firm",
+              "right-to-appoint-and-remove-person",
+              "right-to-appoint-and-remove-person-as-firm",
+              "right-to-appoint-and-remove-person-as-trust",
+              "right-to-appoint-and-remove-directors-registered-overseas-entity",
+              "right-to-appoint-and-remove-directors-as-trust-registered-overseas-entity",
+              "right-to-appoint-and-remove-directors-as-firm-registered-overseas-entity"
+            ]
+          },
+          "type": "array"
+        },
+        "notified_on": {
+          "format": "date",
+          "type": "string"
+        },
+        "reference_etag": {
+          "type": "string"
+        },
+        "reference_psc_id": {
+          "type": "string"
+        },
+        "register_entry_date": {
+          "format": "date",
+          "type": "string"
+        },
+        "residential_address": {
+          "$ref": "#/definitions/Address"
+        },
+        "residential_address_same_as_correspondence_address": {
+          "type": "boolean"
+        },
+        "statementActionDate": {
+          "format": "date",
+          "type": "string"
+        },
+        "statementType": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "PscIndividualFiling": {
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/Address"
+        },
+        "address_same_as_registered_office_address": {
+          "type": "boolean"
+        },
+        "ceased_on": {
+          "format": "date",
+          "type": "string"
+        },
+        "country_of_residence": {
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time",
+          "readOnly": true,
+          "type": "string"
+        },
+        "date_of_birth": {
+          "$ref": "#/definitions/Date"
+        },
+        "etag": {
+          "readOnly": true,
+          "type": "string"
+        },
+        "id": {
+          "readOnly": true,
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "links": {
+          "$ref": "#/definitions/Links"
+        },
+        "name_elements": {
+          "$ref": "#/definitions/NameElements"
+        },
+        "nationality": {
+          "type": "string"
+        },
+        "natures_of_control": {
+          "items": {
+            "type": "string",
+            "enum": [
+              "ownership-of-shares-25-to-50-percent",
+              "ownership-of-shares-50-to-75-percent",
+              "ownership-of-shares-75-to-100-percent",
+              "ownership-of-shares-25-to-50-percent-as-trust",
+              "ownership-of-shares-50-to-75-percent-as-trust",
+              "ownership-of-shares-75-to-100-percent-as-trust",
+              "ownership-of-shares-25-to-50-percent-as-firm",
+              "ownership-of-shares-50-to-75-percent-as-firm",
+              "ownership-of-shares-75-to-100-percent-as-firm",
+              "ownership-of-shares-more-than-25-percent-registered-overseas-entity",
+              "ownership-of-shares-more-than-25-percent-as-trust-registered-overseas-entity",
+              "ownership-of-shares-more-than-25-percent-as-firm-registered-overseas-entity",
+              "voting-rights-25-to-50-percent",
+              "voting-rights-50-to-75-percent",
+              "voting-rights-75-to-100-percent",
+              "voting-rights-25-to-50-percent-as-trust",
+              "voting-rights-50-to-75-percent-as-trust",
+              "voting-rights-75-to-100-percent-as-trust",
+              "voting-rights-25-to-50-percent-as-firm",
+              "voting-rights-50-to-75-percent-as-firm",
+              "voting-rights-75-to-100-percent-as-firm",
+              "voting-rights-more-than-25-percent-registered-overseas-entity",
+              "voting-rights-more-than-25-percent-as-trust-registered-overseas-entity",
+              "voting-rights-more-than-25-percent-as-firm-registered-overseas-entity",
+              "right-to-appoint-and-remove-directors",
+              "right-to-appoint-and-remove-directors-as-trust",
+              "right-to-appoint-and-remove-directors-as-firm",
+              "significant-influence-or-control",
+              "significant-influence-or-control-as-trust",
+              "significant-influence-or-control-as-firm",
+              "right-to-share-surplus-assets-25-to-50-percent-limited-liability-partnership",
+              "right-to-share-surplus-assets-50-to-75-percent-limited-liability-partnership",
+              "right-to-share-surplus-assets-75-to-100-percent-limited-liability-partnership",
+              "right-to-share-surplus-assets-25-to-50-percent-as-trust-limited-liability-partnership",
+              "right-to-share-surplus-assets-50-to-75-percent-as-trust-limited-liability-partnership",
+              "right-to-share-surplus-assets-75-to-100-percent-as-trust-limited-liability-partnership",
+              "right-to-share-surplus-assets-25-to-50-percent-as-firm-limited-liability-partnership",
+              "right-to-share-surplus-assets-50-to-75-percent-as-firm-limited-liability-partnership",
+              "right-to-share-surplus-assets-75-to-100-percent-as-firm-limited-liability-partnership",
+              "voting-rights-25-to-50-percent-limited-liability-partnership",
+              "voting-rights-50-to-75-percent-limited-liability-partnership",
+              "voting-rights-75-to-100-percent-limited-liability-partnership",
+              "voting-rights-25-to-50-percent-as-trust-limited-liability-partnership",
+              "voting-rights-50-to-75-percent-as-trust-limited-liability-partnership",
+              "voting-rights-75-to-100-percent-as-trust-limited-liability-partnership",
+              "voting-rights-25-to-50-percent-as-firm-limited-liability-partnership",
+              "voting-rights-50-to-75-percent-as-firm-limited-liability-partnership",
+              "voting-rights-75-to-100-percent-as-firm-limited-liability-partnership",
+              "right-to-appoint-and-remove-members-limited-liability-partnership",
+              "right-to-appoint-and-remove-members-as-trust-limited-liability-partnership",
+              "right-to-appoint-and-remove-members-as-firm-limited-liability-partnership",
+              "significant-influence-or-control-limited-liability-partnership",
+              "significant-influence-or-control-as-trust-limited-liability-partnership",
+              "significant-influence-or-control-as-firm-limited-liability-partnership",
+              "significant-influence-or-control-registered-overseas-entity",
+              "significant-influence-or-control-as-trust-registered-overseas-entity",
+              "significant-influence-or-control-as-firm-registered-overseas-entity",
+              "part-right-to-share-surplus-assets-25-to-50-percent",
+              "part-right-to-share-surplus-assets-50-to-75-percent",
+              "part-right-to-share-surplus-assets-75-to-100-percent",
+              "part-right-to-share-surplus-assets-25-to-50-percent-as-trust",
+              "part-right-to-share-surplus-assets-50-to-75-percent-as-trust",
+              "part-right-to-share-surplus-assets-75-to-100-percent-as-trust",
+              "part-right-to-share-surplus-assets-25-to-50-percent-as-firm",
+              "part-right-to-share-surplus-assets-50-to-75-percent-as-firm",
+              "part-right-to-share-surplus-assets-75-to-100-percent-as-firm",
+              "right-to-appoint-and-remove-person",
+              "right-to-appoint-and-remove-person-as-firm",
+              "right-to-appoint-and-remove-person-as-trust",
+              "right-to-appoint-and-remove-directors-registered-overseas-entity",
+              "right-to-appoint-and-remove-directors-as-trust-registered-overseas-entity",
+              "right-to-appoint-and-remove-directors-as-firm-registered-overseas-entity"
+            ]
+          },
+          "type": "array"
+        },
+        "notified_on": {
+          "format": "date",
+          "type": "string"
+        },
+        "reference_etag": {
+          "type": "string"
+        },
+        "reference_psc_id": {
+          "type": "string"
+        },
+        "register_entry_date": {
+          "format": "date",
+          "type": "string"
+        },
+        "residential_address": {
+          "$ref": "#/definitions/Address"
+        },
+        "residential_address_same_as_correspondence_address": {
+          "type": "boolean"
+        },
+        "statementActionDate": {
+          "format": "date",
+          "type": "string"
+        },
+        "statementType": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time",
+          "readOnly": true,
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "PscWithIdentification": {
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/Address"
+        },
+        "address_same_as_registered_office_address": {
+          "type": "boolean"
+        },
+        "ceased_on": {
+          "format": "date",
+          "type": "string"
+        },
+        "identification": {
+          "$ref": "#/definitions/Identification"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "links": {
+          "$ref": "#/definitions/Links"
+        },
+        "name": {
+          "type": "string"
+        },
+        "naturesOfControl": {
+          "items": {
+            "type": "string",
+            "enum": [
+              "ownership-of-shares-25-to-50-percent",
+              "ownership-of-shares-50-to-75-percent",
+              "ownership-of-shares-75-to-100-percent",
+              "ownership-of-shares-25-to-50-percent-as-trust",
+              "ownership-of-shares-50-to-75-percent-as-trust",
+              "ownership-of-shares-75-to-100-percent-as-trust",
+              "ownership-of-shares-25-to-50-percent-as-firm",
+              "ownership-of-shares-50-to-75-percent-as-firm",
+              "ownership-of-shares-75-to-100-percent-as-firm",
+              "ownership-of-shares-more-than-25-percent-registered-overseas-entity",
+              "ownership-of-shares-more-than-25-percent-as-trust-registered-overseas-entity",
+              "ownership-of-shares-more-than-25-percent-as-firm-registered-overseas-entity",
+              "voting-rights-25-to-50-percent",
+              "voting-rights-50-to-75-percent",
+              "voting-rights-75-to-100-percent",
+              "voting-rights-25-to-50-percent-as-trust",
+              "voting-rights-50-to-75-percent-as-trust",
+              "voting-rights-75-to-100-percent-as-trust",
+              "voting-rights-25-to-50-percent-as-firm",
+              "voting-rights-50-to-75-percent-as-firm",
+              "voting-rights-75-to-100-percent-as-firm",
+              "voting-rights-more-than-25-percent-registered-overseas-entity",
+              "voting-rights-more-than-25-percent-as-trust-registered-overseas-entity",
+              "voting-rights-more-than-25-percent-as-firm-registered-overseas-entity",
+              "right-to-appoint-and-remove-directors",
+              "right-to-appoint-and-remove-directors-as-trust",
+              "right-to-appoint-and-remove-directors-as-firm",
+              "significant-influence-or-control",
+              "significant-influence-or-control-as-trust",
+              "significant-influence-or-control-as-firm",
+              "right-to-share-surplus-assets-25-to-50-percent-limited-liability-partnership",
+              "right-to-share-surplus-assets-50-to-75-percent-limited-liability-partnership",
+              "right-to-share-surplus-assets-75-to-100-percent-limited-liability-partnership",
+              "right-to-share-surplus-assets-25-to-50-percent-as-trust-limited-liability-partnership",
+              "right-to-share-surplus-assets-50-to-75-percent-as-trust-limited-liability-partnership",
+              "right-to-share-surplus-assets-75-to-100-percent-as-trust-limited-liability-partnership",
+              "right-to-share-surplus-assets-25-to-50-percent-as-firm-limited-liability-partnership",
+              "right-to-share-surplus-assets-50-to-75-percent-as-firm-limited-liability-partnership",
+              "right-to-share-surplus-assets-75-to-100-percent-as-firm-limited-liability-partnership",
+              "voting-rights-25-to-50-percent-limited-liability-partnership",
+              "voting-rights-50-to-75-percent-limited-liability-partnership",
+              "voting-rights-75-to-100-percent-limited-liability-partnership",
+              "voting-rights-25-to-50-percent-as-trust-limited-liability-partnership",
+              "voting-rights-50-to-75-percent-as-trust-limited-liability-partnership",
+              "voting-rights-75-to-100-percent-as-trust-limited-liability-partnership",
+              "voting-rights-25-to-50-percent-as-firm-limited-liability-partnership",
+              "voting-rights-50-to-75-percent-as-firm-limited-liability-partnership",
+              "voting-rights-75-to-100-percent-as-firm-limited-liability-partnership",
+              "right-to-appoint-and-remove-members-limited-liability-partnership",
+              "right-to-appoint-and-remove-members-as-trust-limited-liability-partnership",
+              "right-to-appoint-and-remove-members-as-firm-limited-liability-partnership",
+              "significant-influence-or-control-limited-liability-partnership",
+              "significant-influence-or-control-as-trust-limited-liability-partnership",
+              "significant-influence-or-control-as-firm-limited-liability-partnership",
+              "significant-influence-or-control-registered-overseas-entity",
+              "significant-influence-or-control-as-trust-registered-overseas-entity",
+              "significant-influence-or-control-as-firm-registered-overseas-entity",
+              "part-right-to-share-surplus-assets-25-to-50-percent",
+              "part-right-to-share-surplus-assets-50-to-75-percent",
+              "part-right-to-share-surplus-assets-75-to-100-percent",
+              "part-right-to-share-surplus-assets-25-to-50-percent-as-trust",
+              "part-right-to-share-surplus-assets-50-to-75-percent-as-trust",
+              "part-right-to-share-surplus-assets-75-to-100-percent-as-trust",
+              "part-right-to-share-surplus-assets-25-to-50-percent-as-firm",
+              "part-right-to-share-surplus-assets-50-to-75-percent-as-firm",
+              "part-right-to-share-surplus-assets-75-to-100-percent-as-firm",
+              "right-to-appoint-and-remove-person",
+              "right-to-appoint-and-remove-person-as-firm",
+              "right-to-appoint-and-remove-person-as-trust",
+              "right-to-appoint-and-remove-directors-registered-overseas-entity",
+              "right-to-appoint-and-remove-directors-as-trust-registered-overseas-entity",
+              "right-to-appoint-and-remove-directors-as-firm-registered-overseas-entity"
+            ]
+          },
+          "type": "array"
+        },
+        "reference_etag": {
+          "type": "string"
+        },
+        "reference_psc_id": {
+          "type": "string"
+        },
+        "register_entry_date": {
+          "format": "date",
+          "type": "string"
+        },
+        "statementActionDate": {
+          "format": "date",
+          "type": "string"
+        },
+        "statementType": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "PscWithIdentificationFiling": {
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/Address"
+        },
+        "address_same_as_registered_office_address": {
+          "type": "boolean"
+        },
+        "ceased_on": {
+          "format": "date",
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time",
+          "readOnly": true,
+          "type": "string"
+        },
+        "etag": {
+          "readOnly": true,
+          "type": "string"
+        },
+        "id": {
+          "readOnly": true,
+          "type": "string"
+        },
+        "identification": {
+          "$ref": "#/definitions/Identification"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "links": {
+          "$ref": "#/definitions/Links"
+        },
+        "name": {
+          "type": "string"
+        },
+        "naturesOfControl": {
+          "items": {
+            "type": "string",
+            "enum": [
+              "ownership-of-shares-25-to-50-percent",
+              "ownership-of-shares-50-to-75-percent",
+              "ownership-of-shares-75-to-100-percent",
+              "ownership-of-shares-25-to-50-percent-as-trust",
+              "ownership-of-shares-50-to-75-percent-as-trust",
+              "ownership-of-shares-75-to-100-percent-as-trust",
+              "ownership-of-shares-25-to-50-percent-as-firm",
+              "ownership-of-shares-50-to-75-percent-as-firm",
+              "ownership-of-shares-75-to-100-percent-as-firm",
+              "ownership-of-shares-more-than-25-percent-registered-overseas-entity",
+              "ownership-of-shares-more-than-25-percent-as-trust-registered-overseas-entity",
+              "ownership-of-shares-more-than-25-percent-as-firm-registered-overseas-entity",
+              "voting-rights-25-to-50-percent",
+              "voting-rights-50-to-75-percent",
+              "voting-rights-75-to-100-percent",
+              "voting-rights-25-to-50-percent-as-trust",
+              "voting-rights-50-to-75-percent-as-trust",
+              "voting-rights-75-to-100-percent-as-trust",
+              "voting-rights-25-to-50-percent-as-firm",
+              "voting-rights-50-to-75-percent-as-firm",
+              "voting-rights-75-to-100-percent-as-firm",
+              "voting-rights-more-than-25-percent-registered-overseas-entity",
+              "voting-rights-more-than-25-percent-as-trust-registered-overseas-entity",
+              "voting-rights-more-than-25-percent-as-firm-registered-overseas-entity",
+              "right-to-appoint-and-remove-directors",
+              "right-to-appoint-and-remove-directors-as-trust",
+              "right-to-appoint-and-remove-directors-as-firm",
+              "significant-influence-or-control",
+              "significant-influence-or-control-as-trust",
+              "significant-influence-or-control-as-firm",
+              "right-to-share-surplus-assets-25-to-50-percent-limited-liability-partnership",
+              "right-to-share-surplus-assets-50-to-75-percent-limited-liability-partnership",
+              "right-to-share-surplus-assets-75-to-100-percent-limited-liability-partnership",
+              "right-to-share-surplus-assets-25-to-50-percent-as-trust-limited-liability-partnership",
+              "right-to-share-surplus-assets-50-to-75-percent-as-trust-limited-liability-partnership",
+              "right-to-share-surplus-assets-75-to-100-percent-as-trust-limited-liability-partnership",
+              "right-to-share-surplus-assets-25-to-50-percent-as-firm-limited-liability-partnership",
+              "right-to-share-surplus-assets-50-to-75-percent-as-firm-limited-liability-partnership",
+              "right-to-share-surplus-assets-75-to-100-percent-as-firm-limited-liability-partnership",
+              "voting-rights-25-to-50-percent-limited-liability-partnership",
+              "voting-rights-50-to-75-percent-limited-liability-partnership",
+              "voting-rights-75-to-100-percent-limited-liability-partnership",
+              "voting-rights-25-to-50-percent-as-trust-limited-liability-partnership",
+              "voting-rights-50-to-75-percent-as-trust-limited-liability-partnership",
+              "voting-rights-75-to-100-percent-as-trust-limited-liability-partnership",
+              "voting-rights-25-to-50-percent-as-firm-limited-liability-partnership",
+              "voting-rights-50-to-75-percent-as-firm-limited-liability-partnership",
+              "voting-rights-75-to-100-percent-as-firm-limited-liability-partnership",
+              "right-to-appoint-and-remove-members-limited-liability-partnership",
+              "right-to-appoint-and-remove-members-as-trust-limited-liability-partnership",
+              "right-to-appoint-and-remove-members-as-firm-limited-liability-partnership",
+              "significant-influence-or-control-limited-liability-partnership",
+              "significant-influence-or-control-as-trust-limited-liability-partnership",
+              "significant-influence-or-control-as-firm-limited-liability-partnership",
+              "significant-influence-or-control-registered-overseas-entity",
+              "significant-influence-or-control-as-trust-registered-overseas-entity",
+              "significant-influence-or-control-as-firm-registered-overseas-entity",
+              "part-right-to-share-surplus-assets-25-to-50-percent",
+              "part-right-to-share-surplus-assets-50-to-75-percent",
+              "part-right-to-share-surplus-assets-75-to-100-percent",
+              "part-right-to-share-surplus-assets-25-to-50-percent-as-trust",
+              "part-right-to-share-surplus-assets-50-to-75-percent-as-trust",
+              "part-right-to-share-surplus-assets-75-to-100-percent-as-trust",
+              "part-right-to-share-surplus-assets-25-to-50-percent-as-firm",
+              "part-right-to-share-surplus-assets-50-to-75-percent-as-firm",
+              "part-right-to-share-surplus-assets-75-to-100-percent-as-firm",
+              "right-to-appoint-and-remove-person",
+              "right-to-appoint-and-remove-person-as-firm",
+              "right-to-appoint-and-remove-person-as-trust",
+              "right-to-appoint-and-remove-directors-registered-overseas-entity",
+              "right-to-appoint-and-remove-directors-as-trust-registered-overseas-entity",
+              "right-to-appoint-and-remove-directors-as-firm-registered-overseas-entity"
+            ]
+          },
+          "type": "array"
+        },
+        "notified_on": {
+          "format": "date",
+          "type": "string"
+        },
+        "reference_etag": {
+          "type": "string"
+        },
+        "reference_psc_id": {
+          "type": "string"
+        },
+        "register_entry_date": {
+          "format": "date",
+          "type": "string"
+        },
+        "statementActionDate": {
+          "format": "date",
+          "type": "string"
+        },
+        "statementType": {
+          "type": "string"
+        },
+        "updated_at": {
+          "format": "date-time",
+          "readOnly": true,
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ValidationStatusError": {
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        },
+        "location_type": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ValidationStatusResponse": {
+      "properties": {
+        "errors": {
+          "items": {
+            "$ref": "#/definitions/ValidationStatusError"
+          },
+          "type": "array"
+        },
+        "is_valid": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "x-components": {}
 }

--- a/docs/spec-v2.0.json
+++ b/docs/spec-v2.0.json
@@ -55,6 +55,13 @@
             "description": "For convenience the response body contains details of the created filing resource.",
             "schema": {
               "$ref": "#/definitions/PscFiling"
+            },
+            "headers": {
+              "Location": {
+                "description": "The URI of the newly created filing resource.",
+                "type": "string",
+                "format": "uri"
+              }
             }
           },
           "400": {
@@ -360,6 +367,13 @@
       "description": "For convenience the response body provides the details of the updated filing resource.",
       "schema": {
         "$ref": "#/definitions/PscFiling"
+      },
+      "headers": {
+        "Location": {
+          "description": "The URI of the updated filing resource.",
+          "type": "string",
+          "format": "uri"
+        }
       }
     },
     "Unauthorized": {

--- a/docs/spec-v2.0.json
+++ b/docs/spec-v2.0.json
@@ -76,22 +76,13 @@
             "description": "Forbidden \n* The authorization identity type must equal 'key' \n* The authenticated user account must have internal user privileges \n* The request must have an API key that has internal application privileges"
           },
           "404": {
-            "description": "Not Found",
-            "schema": {
-              "$ref": "#/definitions/ApiErrors"
-            }
+              "$ref": "#/responses/FilingNotFound"
           },
           "409": {
-            "description": "Conflict",
-            "schema": {
-              "$ref": "#/definitions/ApiErrors"
-            }
+            "$ref": "#/responses/Conflict"
           },
           "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/ApiErrors"
-            }
+            "$ref": "#/responses/InternalServerError"
           }
         },
         "tags": [
@@ -125,22 +116,13 @@
             "$ref": "#/responses/Unauthorized"
           },
           "404": {
-            "description": "Not Found",
-            "schema": {
-              "$ref": "#/definitions/ApiErrors"
-            }
+            "$ref": "#/responses/FilingNotFound"
           },
           "409": {
-            "description": "Conflict",
-            "schema": {
-              "$ref": "#/definitions/ApiErrors"
-            }
+            "$ref": "#/responses/Conflict"
           },
           "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/ApiErrors"
-            }
+            "$ref": "#/responses/InternalServerError"
           }
         },
         "tags": [
@@ -185,22 +167,13 @@
             "$ref": "#/responses/Forbidden"
           },
           "404": {
-            "description": "Not Found",
-            "schema": {
-              "$ref": "#/definitions/ApiErrors"
-            }
+            "$ref": "#/responses/NotFound"
           },
           "409": {
-            "description": "Conflict",
-            "schema": {
-              "$ref": "#/definitions/ApiErrors"
-            }
+            "$ref": "#/responses/Conflict"
           },
           "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/ApiErrors"
-            }
+            "$ref": "#/responses/InternalServerError"
           }
         },
         "tags": [
@@ -245,22 +218,13 @@
             "$ref": "#/responses/Forbidden"
           },
           "404": {
-            "description": "Not Found",
-            "schema": {
-              "$ref": "#/definitions/ApiErrors"
-            }
+            "$ref": "#/responses/NotFound"
           },
           "409": {
-            "description": "Conflict",
-            "schema": {
-              "$ref": "#/definitions/ApiErrors"
-            }
+            "$ref": "#/responses/Conflict"
           },
           "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/ApiErrors"
-            }
+            "$ref": "#/responses/InternalServerError"
           }
         },
         "tags": [
@@ -305,22 +269,13 @@
             "$ref": "#/responses/Forbidden"
           },
           "404": {
-            "description": "Not Found",
-            "schema": {
-              "$ref": "#/definitions/ApiErrors"
-            }
+            "$ref": "#/responses/NotFound"
           },
           "409": {
-            "description": "Conflict",
-            "schema": {
-              "$ref": "#/definitions/ApiErrors"
-            }
+            "$ref": "#/responses/Conflict"
           },
           "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/ApiErrors"
-            }
+            "$ref": "#/responses/InternalServerError"
           }
         },
         "tags": [
@@ -354,19 +309,13 @@
             "$ref": "#/responses/Unauthorized"
           },
           "404": {
-            "$ref": "#/responses/NotFound"
+            "$ref": "#/responses/FilingNotFound"
           },
           "409": {
-            "description": "Conflict",
-            "schema": {
-              "$ref": "#/definitions/ApiErrors"
-            }
+            "$ref": "#/responses/Conflict"
           },
           "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/ApiErrors"
-            }
+            "$ref": "#/responses/InternalServerError"
           }
         },
         "tags": [
@@ -423,16 +372,10 @@
             "$ref": "#/responses/FilingNotFound"
           },
           "409": {
-            "description": "Conflict",
-            "schema": {
-              "$ref": "#/definitions/ApiErrors"
-            }
+            "$ref": "#/responses/Conflict"
           },
           "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/ApiErrors"
-            }
+            "$ref": "#/responses/InternalServerError"
           }
         },
         "tags": [
@@ -449,7 +392,7 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "description": "The current open transaction ID for the resource",
+      "description": "The current open transaction ID for the filing resource",
       "x-example": "142481-538116-714607"
     },
     "pscType": {
@@ -462,7 +405,7 @@
         "corporate-entity",
         "legal-person"
       ],
-      "description": "The kind of PSC of the resource",
+      "description": "The kind of PSC of the filing resource",
       "x-example": "individual"
     },
     "filingResourceId": {
@@ -470,75 +413,49 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "description": "The unique filing ID of the resource",
+      "description": "The unique ID of the filing resource",
       "x-example": "63a0776f339d254f9fc04a35"
     }
   },
   "responses": {
-    "PscIndividualFilingCreated": {
-      "description": "The filing resource was created.",
+    "Conflict": {
+      "description": "#### Conflict\nThe request could not be fulfilled due to any of:\n* The company's type is not one that allows the request:\n\t- `private-unlimited`\n\t- `ltd`\n\t- `plc`\n\t- `old-public-company`\n\t- `private-limited-guarant-nsc-limited-exemption`\n\t- `private-limited-guarant-nsc`\n\t- `private-unlimited-nsc`\n\t- `private-limited-shares-section-30-exemption`\n* The company's status is one that forbids the request:\n\t- `dissolved`\n\t- `converted-closed`\n* The company has one or more PSCs whose details are protected.",
       "schema": {
-        "$ref": "#/definitions/PscIndividualFiling"
+        "$ref": "#/definitions/ApiErrors"
       },
       "examples": {
         "application/json": {
-          "ceased_on": "2022-08-29",
-          "links": {
-            "self": "/transactions/021576-444716-850996/persons-with-significant-control/individual/6470946f9f4c3f6c1ed25a19",
-            "validation_status": "/transactions/021576-444716-850996/persons-with-significant-control/6470946f9f4c3f6c1ed25a19/validation_status"
-          },
-          "reference_etag": "8cb9d4c9ba82059ff01ed638105bc41c1bc4db40",
-          "reference_psc_id": "1kdaTltWeaP1EB70SSD9SLmiK5Y",
-          "register_entry_date": "2022-10-15",
-          "id": "6470946f9f4c3f6c1ed25a19",
-          "created_at": "2023-05-26T11:13:51.787Z",
-          "updated_at": "2023-05-26T11:13:51.787Z"
+          "errors": [
+            {
+              "error": "You cannot submit a filing for a company that is Dissolved",
+              "location": "$",
+              "location_type": "json-path",
+              "type": "ch:validation"
+            }
+          ]
         }
       }
     },
-    "PscCorporateEntityFilingCreated": {
-      "description": "The filing resource was created.",
-      "schema": {
-        "$ref": "#/definitions/PscWithIdentificationFiling"
-      },
+    "CreateFilingBadRequest": {
+      "description": "#### Bad Request\nThe request to create a filing resource contains bad data.",
       "examples": {
         "application/json": {
-          "ceased_on": "2023-04-19",
-          "links": {
-            "self": "/transactions/098781-975316-819849/persons-with-significant-control/corporate-entity/64410d94aa51447dcf469570",
-            "validation_status": "/transactions/098781-975316-819849/persons-with-significant-control/64410d94aa51447dcf469570/validation_status"
-          },
-          "reference_etag": "4e5fda8b2b6dba10862965ee34d80915d7b48266",
-          "reference_psc_id": "fhhMkjhxbWGc0juOZvDhNcbFn8o",
-          "register_entry_date": "2023-04-19",
-          "id": "64410d94aa51447dcf469570",
-          "created_at": "2023-04-20T10:01:56.129Z",
-          "updated_at": "2023-04-20T10:01:56.129Z"
-        }
-      }
-    },
-    "PscLegalPersonFilingCreated": {
-      "description": "The filing resource was created.",
-      "schema": {
-        "$ref": "#/definitions/PscWithIdentificationFiling"
-      },
-      "examples": {
-        "application/json": {
-          "links": {
-            "self": "/transactions/116642-036916-819881/persons-with-significant-control/legal-person/64411a2faa51447dcf469693",
-            "validation_status": "/transactions/116642-036916-819881/persons-with-significant-control/64411a2faa51447dcf469693/validation_status"
-          },
-          "reference_etag": "b1786d54fd49e0cd21a3bf402819370f35d24ad1",
-          "reference_psc_id": "OTk2OTA1NDg4OExJSzBNUjFR",
-          "register_entry_date": "2023-04-19T23:00:00.000Z",
-          "id": "64411a2faa51447dcf469693",
-          "created_at": "2023-04-20T10:55:43.695Z",
-          "updated_at": "2023-04-20T10:55:43.695Z"
+          "errors": [
+            {
+              "error": "{rejected-value} must be a date in the past or in the present",
+              "error_values": {
+                "rejected-value": "3000-08-29"
+              },
+              "location": "$.ceased_on",
+              "location_type": "json-path",
+              "type": "ch:validation"
+            }
+          ]
         }
       }
     },
     "FilingFound": {
-      "description": "The filing resource was found.",
+      "description": "#### OK\nThe response body provides the representation of the found filing resource.",
       "schema": {
         "$ref": "#/definitions/PscIndividualFiling"
       },
@@ -559,7 +476,7 @@
       }
     },
     "FilingNotFound": {
-      "description": "The filing resource could not be found. A filing having the specified combination of transaction ID, filing resource ID and PSC type does not exist.",
+      "description": "#### Not Found\nA filing having the specified combination of transaction ID, filing resource ID and PSC type could not be found.",
       "schema": {
         "$ref": "#/definitions/ApiErrors"
       },
@@ -579,14 +496,94 @@
         }
       }
     },
-    "NotFound": {
-      "description": "The filing resource could not be found because of any of these conditions: \n* The transaction ID in the request path does not match an existing transaction or \n * The filing ID in the request path does not match an existing PSC filing or \n* The combination of the transaction ID, filing resource ID and PSC type does not match an existing PSC filing."
-    },
     "Forbidden": {
-      "description": "The operation is not allowed or the resource's transaction is not in an open state."
+      "description": "#### Forbidden\nThe filing resource transaction is not in an open state, or the operation is otherwise not allowed."
+    },
+    "InternalServerError": {
+      "description": "#### Internal Server Error\nThe request could not be fulfilled due to an internal error.",
+      "schema": {
+        "$ref": "#/definitions/ApiErrors"
+      },
+      "examples": {
+        "application/json": {
+          "errors": [
+            {
+              "error": "Service Unavailable",
+              "location": "/transactions/207544-458216-854608/persons-with-significant-control/individual",
+              "location_type": "resource",
+              "type": "ch:service"
+            }
+          ]
+        }
+      }
+    },
+    "NotFound": {
+      "description": "Not Found\nThe filing resource could not be created due to any of: \n* The transaction ID in the request path does not match an existing transaction or\n* The PSC type in the last segment of the path does not match one of the accepted values:\n\t* `individual`\n\t* `corporate-entity`\n\t* `legal-person`"
+    },
+    "PscIndividualFilingCreated": {
+      "description": "#### Created\nFor convenience the response body provides the representation of the created filing resource.",
+      "schema": {
+        "$ref": "#/definitions/PscIndividualFiling"
+      },
+      "examples": {
+        "application/json": {
+          "ceased_on": "2022-08-29",
+          "links": {
+            "self": "/transactions/021576-444716-850996/persons-with-significant-control/individual/6470946f9f4c3f6c1ed25a19",
+            "validation_status": "/transactions/021576-444716-850996/persons-with-significant-control/6470946f9f4c3f6c1ed25a19/validation_status"
+          },
+          "reference_etag": "8cb9d4c9ba82059ff01ed638105bc41c1bc4db40",
+          "reference_psc_id": "1kdaTltWeaP1EB70SSD9SLmiK5Y",
+          "register_entry_date": "2022-10-15",
+          "id": "6470946f9f4c3f6c1ed25a19",
+          "created_at": "2023-05-26T11:13:51.787Z",
+          "updated_at": "2023-05-26T11:13:51.787Z"
+        }
+      }
+    },
+    "PscCorporateEntityFilingCreated": {
+      "description": "#### Created\nFor convenience the response body provides the representation of the created filing resource.",
+      "schema": {
+        "$ref": "#/definitions/PscWithIdentificationFiling"
+      },
+      "examples": {
+        "application/json": {
+          "ceased_on": "2023-04-19",
+          "links": {
+            "self": "/transactions/098781-975316-819849/persons-with-significant-control/corporate-entity/64410d94aa51447dcf469570",
+            "validation_status": "/transactions/098781-975316-819849/persons-with-significant-control/64410d94aa51447dcf469570/validation_status"
+          },
+          "reference_etag": "4e5fda8b2b6dba10862965ee34d80915d7b48266",
+          "reference_psc_id": "fhhMkjhxbWGc0juOZvDhNcbFn8o",
+          "register_entry_date": "2023-04-19",
+          "id": "64410d94aa51447dcf469570",
+          "created_at": "2023-04-20T10:01:56.129Z",
+          "updated_at": "2023-04-20T10:01:56.129Z"
+        }
+      }
+    },
+    "PscLegalPersonFilingCreated": {
+      "description": "#### Created\nFor convenience the response body provides the representation of the created filing resource.",
+      "schema": {
+        "$ref": "#/definitions/PscWithIdentificationFiling"
+      },
+      "examples": {
+        "application/json": {
+          "links": {
+            "self": "/transactions/116642-036916-819881/persons-with-significant-control/legal-person/64411a2faa51447dcf469693",
+            "validation_status": "/transactions/116642-036916-819881/persons-with-significant-control/64411a2faa51447dcf469693/validation_status"
+          },
+          "reference_etag": "b1786d54fd49e0cd21a3bf402819370f35d24ad1",
+          "reference_psc_id": "OTk2OTA1NDg4OExJSzBNUjFR",
+          "register_entry_date": "2023-04-19T23:00:00.000Z",
+          "id": "64411a2faa51447dcf469693",
+          "created_at": "2023-04-20T10:55:43.695Z",
+          "updated_at": "2023-04-20T10:55:43.695Z"
+        }
+      }
     },
     "Unauthorized": {
-      "description": "Invalid or missing credentials",
+      "description": "#### Unauthorized.\nCredentials/authorization are invalid or missing.",
       "schema": {
         "type": "object",
         "properties": {
@@ -600,24 +597,6 @@
         "example": {
           "error": "Invalid Authorization",
           "type": "ch:service"
-        }
-      }
-    },
-    "CreateFilingBadRequest": {
-      "description": "The request to create a filing resource contained bad data.",
-      "examples": {
-        "application/json": {
-          "errors": [
-            {
-              "error": "{rejected-value} must be a date in the past or in the present",
-              "error_values": {
-                "rejected-value": "3000-08-29"
-              },
-              "location": "$.ceased_on",
-              "location_type": "json-path",
-              "type": "ch:validation"
-            }
-          ]
         }
       }
     }

--- a/docs/spec-v2.0.json
+++ b/docs/spec-v2.0.json
@@ -6,8 +6,8 @@
   ],
   "info": {
     "title": "PSC Filing API (Private)",
-    "version": "0.4",
-    "description": "Private specification for the PSC Filings service (currently for PSC07 [Cease a PSC] only).\nIncludes:\n * Public paths for use by third party software filers and CHS, and\n* Private paths for CHS internal users only, and\n* Data models for PSC07 and associated responses.\n\n---\n### NOTE\nFor a PSC07 filing to be valid, at time of closing the transaction the following properties are required:\n* `ceased_on`\n* `register_entry-date`\n* `reference_psc_id`\n* `reference_etag`\n\nThose properties are optional for the 'create' requests and may be added later using an 'update' request."
+    "version": "0.5",
+    "description": "An API that allows clients to submit PSC filings. Currently for PSC07 (Cease a PSC) only."
   },
   "host": "api.chs.local:4001",
   "basePath": "/",
@@ -52,7 +52,10 @@
         ],
         "responses": {
           "201": {
-            "$ref": "#/responses/PscIndividualFilingCreated"
+            "description": "For convenience the response body contains details of the created filing resource.",
+            "schema": {
+              "$ref": "#/definitions/PscFiling"
+            }
           },
           "400": {
             "$ref": "#/responses/CreateFilingBadRequest"
@@ -76,7 +79,7 @@
         "tags": [
           "pscFiling"
         ],
-        "operationId": "createIndividualPscFiling",
+        "operationId": "createFiling",
         "x-operationName": "create filing"
       }
     },
@@ -102,6 +105,9 @@
           "200": {
             "$ref": "#/responses/FilingFound"
           },
+          "400": {
+            "$ref": "#/responses/CreateFilingBadRequest"
+          },
           "401": {
             "$ref": "#/responses/Unauthorized"
           },
@@ -115,12 +121,12 @@
         "tags": [
           "pscFiling"
         ],
-        "operationId": "getFilingForReview",
+        "operationId": "getFiling",
         "x-operationName": "get filing"
       },
       "patch": {
         "summary": "Update this PSC filing resource",
-        "description": "Update permitted properties of a PSC filing resource. Supports adding, replacing or removing properties specified in the request body &mdash; see [RFC7396](https://www.rfc-editor.org/rfc/rfc7396) for details.\n### NOTE\n Certain filing resource properties are **read only** and will be **ignored** if present in the request:\n* `id`\n* `created_at`\n* `updated_at` (modified automatically if the request succeeds)\n* `links`\n",
+        "description": "Update writable properties of a filing resource. See [RFC7396](https://www.rfc-editor.org/rfc/rfc7396) for details, including how to add, replace, and remove properties.",
         "consumes": [
           "application/merge-patch+json"
         ],
@@ -138,7 +144,7 @@
             "$ref": "#/parameters/filingResourceId"
           },
           {
-            "$ref": "#/parameters/patchBody"
+            "$ref": "#/parameters/pscFilingDetails"
           }
         ],
         "responses": {
@@ -188,7 +194,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The validation operation completed successfully. The `is_valid` property in the response body indicates the validity of the filing. The `errors` property in the response body contains details of any validation errors.\n#### Examples:\n<table><tr><td>\n\n**is_valid**\n\n</td><td>\n\n**errors**\n\n</td></tr><tr><td>true</td><td>\n\n`[]`\n\n</td></tr><tr><td>false</td><td>\n\n```\n[\n\t{\n\t\t\"error\": \"PSC register entry date must be on or after the date the PSC was ceased\",\n\t\t\"location\": \"$.register_entry_date\",\n\t\t\"type\": \"ch:validation\",\n\t\t\"location_type\": \"json-path\"\n\t}\n]\n```\n\n</td></tr></table>",
+            "description": "The response properties `is_valid` and `errors` properties specify the result.",
             "schema": {
               "$ref": "#/definitions/ValidationStatus"
             }
@@ -244,19 +250,19 @@
             "description": "Forbidden \n* The authorization identity type must equal '`key`' and \n* The authenticated user account must have internal user privileges and\n* The request must have an API key that has internal application privileges."
           },
           "404": {
-              "$ref": "#/responses/FilingNotFound"
+            "$ref": "#/responses/FilingNotFound"
           },
           "409": {
             "$ref": "#/responses/Conflict"
           },
           "500": {
-            "description": "The request could not be fulfilled due to:\n* The filing resource transaction is not Closed or\n* an internal error."
+            "description": "The request could not be fulfilled because:\n* The filing resource transaction is not Closed or\n* an internal error."
           }
         },
         "tags": [
           "pscFiling"
         ],
-        "operationId": "getFilingsData",
+        "operationId": "getFilingForChips",
         "x-operationName": "get filing for CHIPS"
       }
     }
@@ -291,21 +297,6 @@
       "description": "The unique ID of the filing resource",
       "x-example": "63a0776f339d254f9fc04a35"
     },
-    "patchBody": {
-      "in": "body",
-      "name": "patchBody",
-      "required": true,
-      "schema": {
-        "additionalProperties": {
-          "type": "object"
-        },
-        "type": "object",
-        "title": "patchBody",
-        "example": {
-          "register_entry_date": "2023-02-11"
-        }
-      }
-    },
     "pscFilingDetails": {
       "in": "body",
       "name": "pscFilingDetails",
@@ -318,186 +309,73 @@
   },
   "responses": {
     "Conflict": {
-      "description": "The request could not be fulfilled due to any of:\n* The company's type is not one that allows the request:\n\t- `private-unlimited`\n\t- `ltd`\n\t- `plc`\n\t- `old-public-company`\n\t- `private-limited-guarant-nsc-limited-exemption`\n\t- `private-limited-guarant-nsc`\n\t- `private-unlimited-nsc`\n\t- `private-limited-shares-section-30-exemption`\n* The company's status is one that forbids the request:\n\t- `dissolved`\n\t- `converted-closed`\n* The company has one or more PSCs whose details are protected.",
+      "description": "The request could not be fulfilled because all of the following conditions were not satisfied:\n* The company type **must** be any of:\n\t- `private-unlimited`\n\t- `ltd`\n\t- `plc`\n\t- `old-public-company`\n\t- `private-limited-guarant-nsc-limited-exemption`\n\t- `private-limited-guarant-nsc`\n\t- `private-unlimited-nsc`\n\t- `private-limited-shares-section-30-exemption`\n* The company status **must not** be any of:\n\t- `dissolved`\n\t- `converted-closed`\n* The company **must not** have any PSCs whose details are protected.",
       "schema": {
-        "$ref": "#/definitions/ApiErrors"
-      },
-      "examples": {
-        "application/json": {
-          "errors": [
-            {
-              "error": "You cannot submit a filing for a company that is Dissolved",
-              "location": "$",
-              "location_type": "json-path",
-              "type": "ch:validation"
-            }
-          ]
-        }
+        "$ref": "#/definitions/ConflictErrors"
       }
     },
     "CreateFilingBadRequest": {
       "description": "The request to create a filing resource contains bad data.",
-      "examples": {
-        "application/json": {
-          "errors": [
-            {
-              "error": "{rejected-value} must be a date in the past or in the present",
-              "error_values": {
-                "rejected-value": "3000-08-29"
-              },
-              "location": "$.ceased_on",
-              "location_type": "json-path",
-              "type": "ch:validation"
-            }
-          ]
-        }
+      "schema": {
+        "$ref": "#/definitions/CreateErrors"
       }
     },
     "FilingFound": {
       "description": "The response body provides the details of the found filing resource.",
       "schema": {
-        "$ref": "#/definitions/PscFilingResource"
-      },
-      "examples": {
-        "application/json": {
-          "ceased_on": "2022-08-29",
-          "links": {
-            "self": "/transactions/021576-444716-850996/persons-with-significant-control/individual/6470946f9f4c3f6c1ed25a19",
-            "validation_status": "/transactions/021576-444716-850996/persons-with-significant-control/6470946f9f4c3f6c1ed25a19/validation_status"
-          },
-          "reference_etag": "8cb9d4c9ba82059ff01ed638105bc41c1bc4db40",
-          "reference_psc_id": "1kdaTltWeaP1EB70SSD9SLmiK5Y",
-          "register_entry_date": "2022-08-30",
-          "id": "6470946f9f4c3f6c1ed25a19",
-          "created_at": "2023-05-26T11:13:51.787Z",
-          "updated_at": "2023-05-26T11:13:51.787Z"
-        }
+        "$ref": "#/definitions/PscFiling"
       }
     },
     "FilingNotFound": {
-      "description": "A filing with the specified combination of transaction ID, filing resource ID and PSC type could not be found.",
+      "description": "A filing with the specified combination of `transactionId`, `filingResourceId` and `pscType` could not be found.",
       "schema": {
-        "$ref": "#/definitions/ApiErrors"
-      },
-      "examples": {
-        "application/json": {
-          "errors": [
-            {
-              "error": "Filing resource {filing-resource-id} not found",
-              "error_values": {
-                "{filing-resource-id}": "6470946f9f4c3f6c1ed25a19x"
-              },
-              "location": "/transactions/021576-444716-850996/persons-with-significant-control/individual/6470946f9f4c3f6c1ed25a19x",
-              "location_type": "resource",
-              "type": "ch:validation"
-            }
-          ]
-        }
+        "$ref": "#/definitions/NotFoundErrors"
       }
     },
     "FilingData": {
       "description": "The CHIPS-compatible details of this filing resource.",
       "schema": {
         "items": {
-          "$ref": "#/definitions/chipsFilingResource"
+          "$ref": "#/definitions/ChipsFiling"
         },
-        "type": "array",
-        "example": [
-          {
-            "data": {
-              "title": "Mr",
-              "first_name": "Random",
-              "other_forenames": "Notreal",
-              "last_name": "Person",
-              "ceased_on": "2022-08-29",
-              "register_entry_date": "2022-08-30"
-            },
-            "description": "(PSC07) Notice of ceasing to be a Person of Significant Control for Mr Random Notreal Person on 29 August 2022",
-            "kind": "psc-filing#cessation#individual"
-          }
-        ]
+        "type": "array"
       }
     },
     "Forbidden": {
-      "description": "The filing resource transaction is not in an open state, or the operation is otherwise not allowed."
+      "description": "The transaction with ID `transactionId` is not in an open state, or the operation is otherwise not allowed."
     },
     "InternalServerError": {
-      "description": "The request could not be fulfilled due to an internal error.",
+      "description": "The request could not be fulfilled because of an internal error.",
       "schema": {
-        "$ref": "#/definitions/ApiErrors"
-      },
-      "examples": {
-        "application/json": {
-          "errors": [
-            {
-              "error": "Service Unavailable",
-              "location": "/transactions/207544-458216-854608/persons-with-significant-control/individual",
-              "location_type": "resource",
-              "type": "ch:service"
-            }
-          ]
-        }
+        "$ref": "#/definitions/InternalErrors"
       }
     },
     "NotCreated": {
-      "description": "The filing resource could not be created due to any of: \n* The transaction ID in the request path does not match an existing transaction or\n* The PSC type in the last segment of the path does not match one of the accepted values:\n\t* `individual`\n\t* `corporate-entity`\n\t* `legal-person`"
+      "description": "The filing resource could not be created with the specified combination of `transactionId` and `pscType`."
     },
     "NotFound": {
-      "description": "A filing with the specified combination of transaction ID, filing resource ID and PSC type could not be found."
-    },
-    "PscIndividualFilingCreated": {
-      "description": "For convenience the response body contains details of the created filing resource.",
-      "schema": {
-        "$ref": "#/definitions/PscFilingResource"
-      },
-      "examples": {
-        "application/json": {
-          "ceased_on": "2022-08-29",
-          "links": {
-            "self": "/transactions/021576-444716-850996/persons-with-significant-control/individual/6470946f9f4c3f6c1ed25a19",
-            "validation_status": "/transactions/021576-444716-850996/persons-with-significant-control/6470946f9f4c3f6c1ed25a19/validation_status"
-          },
-          "reference_etag": "8cb9d4c9ba82059ff01ed638105bc41c1bc4db40",
-          "reference_psc_id": "1kdaTltWeaP1EB70SSD9SLmiK5Y",
-          "register_entry_date": "2022-08-30",
-          "id": "6470946f9f4c3f6c1ed25a19",
-          "created_at": "2023-05-26T11:13:51.787Z",
-          "updated_at": "2023-05-26T11:13:51.787Z"
-        }
-      }
+      "description": "A filing with the specified combination of `transactionId`, `filingResourceId` and `pscType` could not be found."
     },
     "PscFilingUpdated": {
       "description": "For convenience the response body provides the details of the updated filing resource.",
       "schema": {
-        "$ref": "#/definitions/PscFilingResource"
-      },
-      "examples": {
-        "application/json": {
-          "ceased_on": "2023-04-19",
-          "links": {
-            "self": "/transactions/098781-975316-819849/persons-with-significant-control/corporate-entity/64410d94aa51447dcf469570",
-            "validation_status": "/transactions/098781-975316-819849/persons-with-significant-control/64410d94aa51447dcf469570/validation_status"
-          },
-          "reference_etag": "4e5fda8b2b6dba10862965ee34d80915d7b48266",
-          "reference_psc_id": "fhhMkjhxbWGc0juOZvDhNcbFn8o",
-          "register_entry_date": "2023-02-11",
-          "id": "64410d94aa51447dcf469570",
-          "created_at": "2023-04-20T10:01:56.129Z",
-          "updated_at": "2023-04-25T12:44:02.290Z"
-        }
+        "$ref": "#/definitions/PscFiling"
       }
     },
     "Unauthorized": {
       "description": "Request credentials/authorization are invalid or missing.",
       "schema": {
         "type": "object",
-        "title": "UnauthorizedResponse",
+        "readOnly": true,
+        "title": "unauthorized",
         "properties": {
           "error": {
-            "type": "string"
+            "type": "string",
+            "description": "Error message"
           },
           "type": {
-            "type": "string"
+            "type": "string",
+            "description": "Error type"
           }
         },
         "example": {
@@ -508,20 +386,8 @@
     },
     "UpdateFilingBadRequest": {
       "description": "The request to update a filing resource contains bad data.",
-      "examples": {
-        "application/json": {
-          "errors": [
-            {
-              "error": "{rejected-value} must be a date in the past or in the present",
-              "error_values": {
-                "rejected-value": "3000-08-30"
-              },
-              "location": "$.ceased_on",
-              "location_type": "json-path",
-              "type": "ch:validation"
-            }
-          ]
-        }
+      "schema": {
+        "$ref": "#/definitions/UpdateErrors"
       }
     }
   },
@@ -546,175 +412,342 @@
     "ApiError": {
       "properties": {
         "error": {
+          "description": "Error message",
           "type": "string"
         },
         "error_values": {
           "additionalProperties": {
-            "type": "string"
+            "type": "string",
+            "description": "Value name"
           },
-          "type": "string"
+          "type": "string",
+          "description": "Associated error values"
         },
         "location": {
-          "type": "string"
+          "type": "string",
+          "description": "Error location"
         },
         "location_type": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "resource",
+            "request-body",
+            "json-path"
+          ],
+          "description": "Location type"
         },
         "type": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "ch:service",
+            "ch:validation"
+          ],
+          "description": "Error type"
         }
       },
       "type": "object",
-      "title": "ApiError"
+      "title": "error"
     },
-    "ApiErrors": {
+    "CreateErrors": {
       "properties": {
         "errors": {
           "items": {
             "$ref": "#/definitions/ApiError"
           },
           "type": "array",
-          "uniqueItems": true
+          "uniqueItems": true,
+          "description": "Errors set"
         }
       },
       "type": "object",
-      "title": "ApiErrors"
+      "title": "create errors",
+      "example": {
+        "errors": [
+          {
+            "error": "{rejected-value} must be a date in the past or in the present",
+            "error_values": {
+              "rejected-value": "3000-08-29"
+            },
+            "location": "$.ceased_on",
+            "location_type": "json-path",
+            "type": "ch:validation"
+          }
+        ]
+      }
     },
-    "chipsFilingResource": {
+    "ConflictErrors": {
+      "properties": {
+        "errors": {
+          "items": {
+            "$ref": "#/definitions/ApiError"
+          },
+          "type": "array",
+          "uniqueItems": true,
+          "description": "Errors set"
+        }
+      },
+      "type": "object",
+      "title": "conflict errors",
+      "example": {
+        "errors": [
+          {
+            "error": "You cannot submit a filing for a company that is Dissolved",
+            "location": "$",
+            "location_type": "json-path",
+            "type": "ch:validation"
+          }
+        ]
+      }
+    },
+    "ChipsFiling": {
       "properties": {
         "data": {
           "additionalProperties": {
-            "type": "object"
+            "type": "object",
+            "readOnly": true,
+            "description": "Data name"
           },
-          "type": "string"
+          "type": "string",
+          "readOnly": true,
+          "description": "Filing data"
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true,
+          "description": "Description"
         },
         "description_identifier": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true,
+          "description": "Description identifier"
         },
         "description_values": {
           "additionalProperties": {
-            "type": "string"
+            "type": "string",
+            "readOnly": true,
+            "description": "Description name"
           },
-          "type": "string"
+          "type": "string",
+          "readOnly": true,
+          "description": "Filing descriptions"
         },
         "kind": {
-          "type": "string"
+          "type": "string",
+          "readOnly": true,
+          "description": "Filing kind"
         }
       },
       "type": "object",
-      "title": "chipsFilingResource",
-      "description": "CHIPS-compatible PSC filing details"
+      "title": "filing for chips",
+      "description": "CHIPS-compatible PSC filing details",
+      "example": [
+        {
+          "data": {
+            "title": "Mr",
+            "first_name": "Random",
+            "other_forenames": "Notreal",
+            "last_name": "Person",
+            "ceased_on": "2022-08-29",
+            "register_entry_date": "2022-08-30"
+          },
+          "description": "(PSC07) Notice of ceasing to be a Person of Significant Control for Mr Random Notreal Person on 29 August 2022",
+          "kind": "psc-filing#cessation#individual"
+        }
+      ]
+    },
+    "InternalErrors": {
+      "properties": {
+        "errors": {
+          "items": {
+            "$ref": "#/definitions/ApiError"
+          },
+          "type": "array",
+          "uniqueItems": true,
+          "description": "Errors set"
+        }
+      },
+      "type": "object",
+      "title": "internal errors",
+      "example": {
+        "errors": [
+          {
+            "error": "Service Unavailable",
+            "location": "/transactions/207544-458216-854608/persons-with-significant-control/individual",
+            "location_type": "resource",
+            "type": "ch:service"
+          }
+        ]
+      }
     },
     "Links": {
+      "description": "Filing resource associated locations",
       "properties": {
         "self": {
+          "description": "Filing resource location",
           "format": "uri",
-          "type": "string"
+          "type": "string",
+          "readOnly": true,
+          "example": "/transactions/021576-444716-850996/persons-with-significant-control/individual/6470946f9f4c3f6c1ed25a19"
         },
         "validation_status": {
+          "description": "Filing resource validation location",
           "format": "uri",
-          "type": "string"
+          "type": "string",
+          "readOnly": true,
+          "example": "/transactions/021576-444716-850996/persons-with-significant-control/6470946f9f4c3f6c1ed25a19/validation_status"
+        }
+      },
+      "readOnly": true,
+      "type": "object",
+      "title": "links"
+    },
+    "NotFoundErrors": {
+      "properties": {
+        "errors": {
+          "items": {
+            "$ref": "#/definitions/ApiError"
+          },
+          "type": "array",
+          "uniqueItems": true,
+          "description": "Errors set"
         }
       },
       "type": "object",
-      "title": "Links"
+      "title": "not found errors",
+      "example": {
+        "errors": [
+          {
+            "error": "Filing resource {filing-resource-id} not found",
+            "error_values": {
+              "{filing-resource-id}": "6470946f9f4c3f6c1ed25a19x"
+            },
+            "location": "/transactions/021576-444716-850996/persons-with-significant-control/individual/6470946f9f4c3f6c1ed25a19x",
+            "location_type": "resource",
+            "type": "ch:validation"
+          }
+        ]
+      }
     },
     "PscFiling": {
       "properties": {
         "ceased_on": {
+          "description": "PSC cessation date",
           "format": "date",
           "type": "string",
           "example": "2022-08-29"
         },
-        "reference_etag": {
-          "type": "string",
-          "example": "8cb9d4c9ba82059ff01ed638105bc41c1bc4db40"
-        },
-        "reference_psc_id": {
-          "type": "string",
-          "example": "1kdaTltWeaP1EB70SSD9SLmiK5Y"
-        },
-        "register_entry_date": {
-          "format": "date",
-          "type": "string",
-          "example": "2022-08-30"
-        }
-      },
-      "type": "object",
-      "title": "PscFiling"
-    },
-    "PscFilingResource": {
-      "properties": {
-        "ceased_on": {
-          "format": "date",
-          "type": "string"
-        },
         "created_at": {
+          "description": "Filing resource creation time",
           "readOnly": true,
           "format": "date-time",
-          "type": "string"
+          "type": "string",
+          "example": "2023-05-26T11:13:51.787Z"
         },
         "id": {
+          "description": "Filing resource ID",
           "readOnly": true,
-          "type": "string"
+          "type": "string",
+          "example": "6470946f9f4c3f6c1ed25a19"
         },
         "links": {
           "$ref": "#/definitions/Links"
         },
         "reference_etag": {
-          "type": "string"
+          "description": "Reference PSC ETag",
+          "type": "string",
+          "example": "8cb9d4c9ba82059ff01ed638105bc41c1bc4db40"
         },
         "reference_psc_id": {
-          "type": "string"
+          "description": "Reference PSC ID",
+          "type": "string",
+          "example": "1kdaTltWeaP1EB70SSD9SLmiK5Y"
         },
         "register_entry_date": {
+          "description": "PSC register updated date",
           "format": "date",
-          "type": "string"
+          "type": "string",
+          "example": "2022-08-30"
         },
         "updated_at": {
+          "description": "Filing resource last modified time",
           "readOnly": true,
           "format": "date-time",
-          "type": "string"
+          "type": "string",
+          "example": "2023-05-26T11:13:51.787Z"
         }
       },
       "type": "object",
-      "title": "PscFilingResource"
+      "title": "psc filing",
+      "example": {
+        "ceased_on": "2022-08-29",
+        "links": {
+          "self": "/transactions/021576-444716-850996/persons-with-significant-control/individual/6470946f9f4c3f6c1ed25a19",
+          "validation_status": "/transactions/021576-444716-850996/persons-with-significant-control/6470946f9f4c3f6c1ed25a19/validation_status"
+        },
+        "reference_etag": "8cb9d4c9ba82059ff01ed638105bc41c1bc4db40",
+        "reference_psc_id": "1kdaTltWeaP1EB70SSD9SLmiK5Y",
+        "register_entry_date": "2022-08-30",
+        "id": "6470946f9f4c3f6c1ed25a19",
+        "created_at": "2023-05-26T11:13:51.787Z",
+        "updated_at": "2023-05-26T11:13:51.787Z"
+      }
     },
-    "ValidationStatusError": {
+    "UpdateErrors": {
       "properties": {
-        "error": {
-          "type": "string"
-        },
-        "location": {
-          "type": "string"
-        },
-        "location_type": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
+        "errors": {
+          "items": {
+            "$ref": "#/definitions/ApiError"
+          },
+          "type": "array",
+          "uniqueItems": true,
+          "description": "Errors set"
         }
       },
       "type": "object",
-      "title": "ValidationStatusError"
+      "title": "update errors",
+      "example": {
+        "errors": [
+          {
+            "error": "{rejected-value} must be a date in the past or in the present",
+            "error_values": {
+              "rejected-value": "3000-08-29"
+            },
+            "location": "$.ceased_on",
+            "location_type": "json-path",
+            "type": "ch:validation"
+          }
+        ]
+      }
     },
     "ValidationStatus": {
       "properties": {
         "errors": {
           "items": {
-            "$ref": "#/definitions/ValidationStatusError"
+            "$ref": "#/definitions/ApiError"
           },
-          "type": "array"
+          "type": "array",
+          "uniqueItems": true,
+          "description": "Errors set",
+          "title": "validation errors"
         },
         "is_valid": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Validation status"
         }
       },
       "type": "object",
-      "title": "ValidationStatus"
+      "title": "validation status",
+      "example": {
+        "errors": [
+          {
+            "error": "PSC register entry date must be on or after the date the PSC was ceased",
+            "location": "$.register_entry_date",
+            "type": "ch:validation",
+            "location_type": "json-path"
+          }
+        ],
+        "is_valid": false
+      }
     }
   }
 }

--- a/docs/spec-v2.0.json
+++ b/docs/spec-v2.0.json
@@ -1,0 +1,939 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "PSC Filing API (Private)",
+    "version": "0.1",
+    "description": "Private specification for receiving PSC filings (PSC07 only) by third party software filers and CHS internal users. \n\n__Note__ this includes private endpoints for CHS internal services."
+  },
+  "host": "api.chs.local:4001",
+  "basePath": "/",
+  "schemes": [
+    "http"
+  ],
+  "security": [
+    {
+      "ERIC oauth2": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Filing Data",
+      "description": "For use by the CHS filing resource handler service."
+    },
+    {
+      "name": "Private",
+      "description": "For internal use only"
+    },
+    {
+      "name": "Validation Status",
+      "description": "For public use and for the CHS transaction service when attempting to close a transaction."
+    },
+    {
+      "name": "Public",
+      "description": "For public use"
+    },
+    {
+      "name": "PSC Filing",
+      "description": "For creating, updating, and retrieving PSC filings"
+    }
+  ],
+  "paths": {
+    "/private/transactions/{transactionId}/persons-with-significant-control/{pscType}/{filingResourceId}/filings": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "security": [
+          {
+            "ERIC API Key": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/transactionId"
+          },
+          {
+            "$ref": "#/parameters/pscType"
+          },
+          {
+            "$ref": "#/parameters/filingResourceId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "items": {
+                "$ref": "#/definitions/FilingApi"
+              },
+              "type": "array"
+            }
+          },
+          "401": {
+            "$ref": "#/responses/Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden \n* The authorization identity type must equal 'key' \n* The authenticated user account must have internal user privileges \n* The request must have an API key that has internal application privileges"
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/ApiErrors"
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "schema": {
+              "$ref": "#/definitions/ApiErrors"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/ApiErrors"
+            }
+          }
+        },
+        "tags": [
+          "Filing Data",
+          "Private"
+        ],
+        "operationId": "getFilingsData"
+      }
+    },
+    "/transactions/{transactionId}/persons-with-significant-control/{filingResourceId}/validation_status": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/transactionId"
+          },
+          {
+            "$ref": "#/parameters/filingResourceId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ValidationStatusResponse"
+            }
+          },
+          "401": {
+            "$ref": "#/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/ApiErrors"
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "schema": {
+              "$ref": "#/definitions/ApiErrors"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/ApiErrors"
+            }
+          }
+        },
+        "tags": [
+          "Validation Status",
+          "Public"
+        ],
+        "operationId": "validate"
+      }
+    },
+    "/transactions/{transactionId}/persons-with-significant-control/{pscType}": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/transactionId"
+          },
+          {
+            "$ref": "#/parameters/pscType"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PscIndividualDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {}
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {}
+          },
+          "401": {
+            "$ref": "#/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/responses/Forbidden"
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/ApiErrors"
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "schema": {
+              "$ref": "#/definitions/ApiErrors"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/ApiErrors"
+            }
+          }
+        },
+        "tags": [
+          "PSC Filing",
+          "Public"
+        ],
+        "operationId": "createFiling_1"
+      }
+    },
+    "/transactions/{transactionId}/persons-with-significant-control/{pscType}/{filingResourceId}": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/transactionId"
+          },
+          {
+            "$ref": "#/parameters/pscType"
+          },
+          {
+            "$ref": "#/parameters/filingResourceId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/FilingFound"
+          },
+          "401": {
+            "$ref": "#/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/responses/NotFound"
+          },
+          "409": {
+            "description": "Conflict",
+            "schema": {
+              "$ref": "#/definitions/ApiErrors"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/ApiErrors"
+            }
+          }
+        },
+        "tags": [
+          "PSC Filing",
+          "Public"
+        ],
+        "operationId": "getFilingForReview"
+      },
+      "patch": {
+        "consumes": [
+          "application/merge-patch+json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/transactionId"
+          },
+          {
+            "$ref": "#/parameters/pscType"
+          },
+          {
+            "$ref": "#/parameters/filingResourceId"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "additionalProperties": {
+                "type": "object"
+              },
+              "type": "object"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {}
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {}
+          },
+          "401": {
+            "$ref": "#/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/responses/FilingNotFound"
+          },
+          "409": {
+            "description": "Conflict",
+            "schema": {
+              "$ref": "#/definitions/ApiErrors"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/ApiErrors"
+            }
+          }
+        },
+        "tags": [
+          "PSC Filing",
+          "Public"
+        ],
+        "operationId": "updateFiling"
+      }
+    }
+  },
+  "parameters": {
+    "transactionId": {
+      "name": "transactionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The current open transaction ID for the resource",
+      "x-example": "142481-538116-714607"
+    },
+    "pscType": {
+      "name": "pscType",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "enum": [
+        "individual",
+        "corporate-entity",
+        "legal-person"
+      ],
+      "description": "The kind of PSC of the resource",
+      "x-example": "individual"
+    },
+    "filingResourceId": {
+      "name": "filingResourceId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The unique filing ID of the resource",
+      "x-example": "63a0776f339d254f9fc04a35"
+    }
+  },
+  "responses": {
+    "FilingFound": {
+      "description": "The filing resource was found.",
+      "schema": {
+        "$ref": "#/definitions/PscIndividualFiling"
+      },
+      "examples": {
+        "application/json": {
+          "ceased_on": "2022-08-29",
+          "links": {
+            "self": "/transactions/021576-444716-850996/persons-with-significant-control/individual/6470946f9f4c3f6c1ed25a19",
+            "validation_status": "/transactions/021576-444716-850996/persons-with-significant-control/6470946f9f4c3f6c1ed25a19/validation_status"
+          },
+          "reference_etag": "8cb9d4c9ba82059ff01ed638105bc41c1bc4db40",
+          "reference_psc_id": "1kdaTltWeaP1EB70SSD9SLmiK5Y",
+          "register_entry_date": "2022-10-15",
+          "id": "6470946f9f4c3f6c1ed25a19",
+          "created_at": "2023-05-26T11:13:51.787Z",
+          "updated_at": "2023-05-26T11:13:51.787Z"
+        }
+      }
+    },
+    "FilingNotFound": {
+      "description": "The filing resource could not be found. A filing having the specified combination of transaction ID, filing resource ID and PSC type does not exist.",
+      "schema": {
+        "$ref": "#/definitions/ApiErrors"
+      },
+      "examples": {
+        "application/json": {
+          "errors": [
+            {
+              "error": "Filing resource {filing-resource-id} not found",
+              "error_values": {
+                "{filing-resource-id}": "6470946f9f4c3f6c1ed25a19x"
+              },
+              "location": "/transactions/021576-444716-850996/persons-with-significant-control/individual/6470946f9f4c3f6c1ed25a19x",
+              "location_type": "resource",
+              "type": "ch:validation"
+            }
+          ]
+        }
+      }
+    },
+    "NotFound": {
+      "description": "The filing resource could not be found because of any of these conditions: \n* The transaction ID in the request path does not match an existing transaction or \n * The filing ID in the request path does not match an existing PSC filing or \n* The combination of the transaction ID, filing resource ID and PSC type does not match an existing PSC filing."
+    },
+    "Forbidden": {
+      "description": "The operation is not allowed or the resource's transaction is not in an open state."
+    },
+    "Unauthorized": {
+      "description": "Invalid or missing credentials",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "example": {
+          "error": "Invalid Authorization",
+          "type": "ch:service"
+        }
+      }
+    }
+},
+"securityDefinitions": {
+"ERIC oauth2": {
+"type": "oauth2",
+"flow": "accessCode",
+"authorizationUrl": "http://account.chs.local/oauth2/authorise",
+"tokenUrl": "http://account.chs.local/oauth2/token",
+"scopes": {
+"https://account.companieshouse.gov.uk/user/profile.read": "User profile read permission",
+"https://api.company-information.service.gov.uk/company/{company_number}/persons-with-significant-control.delete": "Grants permissions to remove a PSC from this company"
+}
+},
+"ERIC API Key": {
+"type": "apiKey",
+"name": "api_key",
+"in": "header"
+}
+},
+"definitions": {
+"Address": {
+"properties": {
+"addressLine1": {
+"type": "string"
+},
+"addressLine2": {
+"type": "string"
+},
+"careOf": {
+"type": "string"
+},
+"country": {
+"type": "string"
+},
+"locality": {
+"type": "string"
+},
+"poBox": {
+"type": "string"
+},
+"postalCode": {
+"type": "string"
+},
+"premises": {
+"type": "string"
+},
+"region": {
+"type": "string"
+}
+},
+"required": [
+"addressLine1"
+],
+"type": "object"
+},
+"AddressDto": {
+"properties": {
+"address_line_1": {
+"type": "string"
+},
+"address_line_2": {
+"type": "string"
+},
+"careOf": {
+"type": "string"
+},
+"country": {
+"type": "string"
+},
+"locality": {
+"type": "string"
+},
+"poBox": {
+"type": "string"
+},
+"postalCode": {
+"type": "string"
+},
+"premises": {
+"type": "string"
+},
+"region": {
+"type": "string"
+}
+},
+"type": "object"
+},
+"ApiError": {
+"properties": {
+"error": {
+"type": "string"
+},
+"errorValues": {
+"additionalProperties": {
+"type": "string"
+},
+"type": "object"
+},
+"location": {
+"type": "string"
+},
+"locationType": {
+"type": "string"
+},
+"type": {
+"type": "string"
+}
+},
+"type": "object"
+},
+"FilingNotFoundError": {
+"type": "object",
+"properties": {
+}
+},
+"ApiErrors": {
+"properties": {
+"errors": {
+"items": {
+"$ref": "#/definitions/ApiError"
+},
+"type": "array",
+"uniqueItems": true
+}
+},
+"type": "object"
+},
+"Date3Tuple": {
+"properties": {
+"day": {
+"format": "int32",
+"type": "integer"
+},
+"month": {
+"format": "int32",
+"type": "integer"
+},
+"year": {
+"format": "int32",
+"type": "integer"
+}
+},
+"type": "object"
+},
+"Date3TupleDto": {
+"properties": {
+"day": {
+"format": "int32",
+"type": "integer"
+},
+"month": {
+"format": "int32",
+"type": "integer"
+},
+"year": {
+"format": "int32",
+"type": "integer"
+}
+},
+"type": "object"
+},
+"FilingApi": {
+"properties": {
+"data": {
+"additionalProperties": {
+"type": "object"
+},
+"type": "object"
+},
+"description": {
+"type": "string"
+},
+"description_identifier": {
+"type": "string"
+},
+"description_values": {
+"additionalProperties": {
+"type": "string"
+},
+"type": "object"
+},
+"kind": {
+"type": "string"
+}
+},
+"type": "object"
+},
+"Identification": {
+"properties": {
+"countryRegistered": {
+"type": "string"
+},
+"legalAuthority": {
+"type": "string"
+},
+"legalForm": {
+"type": "string"
+},
+"placeRegistered": {
+"type": "string"
+},
+"registrationNumber": {
+"type": "string"
+}
+},
+"type": "object"
+},
+"Link": {
+"properties": {
+"href": {
+"type": "string"
+},
+"templated": {
+"type": "boolean"
+}
+},
+"type": "object"
+},
+"Links": {
+"properties": {
+"self": {
+"format": "uri",
+"type": "string"
+},
+"validationStatus": {
+"format": "uri",
+"type": "string"
+}
+},
+"type": "object"
+},
+"NameElements": {
+"properties": {
+"forename": {
+"type": "string"
+},
+"otherForenames": {
+"type": "string"
+},
+"other_forenames": {
+"type": "string"
+},
+"surname": {
+"type": "string"
+},
+"title": {
+"type": "string"
+}
+},
+"type": "object"
+},
+"NameElementsDto": {
+"properties": {
+"forename": {
+"type": "string"
+},
+"otherForenames": {
+"type": "string"
+},
+"other_forenames": {
+"type": "string"
+},
+"surname": {
+"type": "string"
+},
+"title": {
+"type": "string"
+}
+},
+"type": "object"
+},
+"PscIndividualDto": {
+"properties": {
+"address": {
+"$ref": "#/definitions/AddressDto"
+},
+"addressSameAsRegisteredOfficeAddress": {
+"type": "boolean"
+},
+"ceasedOn": {
+"format": "date",
+"type": "string"
+},
+"countryOfResidence": {
+"type": "string"
+},
+"dateOfBirth": {
+"$ref": "#/definitions/Date3TupleDto"
+},
+"nameElements": {
+"$ref": "#/definitions/NameElementsDto"
+},
+"nationality": {
+"type": "string"
+},
+"naturesOfControl": {
+"items": {
+"type": "string"
+},
+"type": "array"
+},
+"notifiedOn": {
+"format": "date",
+"type": "string"
+},
+"referenceEtag": {
+"type": "string"
+},
+"referencePscId": {
+"type": "string"
+},
+"registerEntryDate": {
+"format": "date",
+"type": "string"
+},
+"residentialAddress": {
+"$ref": "#/definitions/AddressDto"
+},
+"residentialAddressSameAsCorrespondenceAddress": {
+"type": "boolean"
+}
+},
+"type": "object"
+},
+"PscIndividualFiling": {
+"properties": {
+"address": {
+"$ref": "#/definitions/Address"
+},
+"addressSameAsRegisteredOfficeAddress": {
+"type": "boolean"
+},
+"ceasedOn": {
+"format": "date",
+"type": "string"
+},
+"countryOfResidence": {
+"type": "string"
+},
+"created_at": {
+"format": "date-time",
+"readOnly": true,
+"type": "string"
+},
+"dateOfBirth": {
+"$ref": "#/definitions/Date3Tuple"
+},
+"etag": {
+"type": "string"
+},
+"id": {
+"readOnly": true,
+"type": "string"
+},
+"kind": {
+"type": "string"
+},
+"links": {
+"$ref": "#/definitions/Links"
+},
+"nameElements": {
+"$ref": "#/definitions/NameElements"
+},
+"nationality": {
+"type": "string"
+},
+"naturesOfControl": {
+"items": {
+"type": "string"
+},
+"type": "array"
+},
+"notifiedOn": {
+"format": "date",
+"type": "string"
+},
+"referenceEtag": {
+"type": "string"
+},
+"referencePscId": {
+"type": "string"
+},
+"registerEntryDate": {
+"format": "date",
+"type": "string"
+},
+"residentialAddress": {
+"$ref": "#/definitions/Address"
+},
+"residentialAddressSameAsCorrespondenceAddress": {
+"type": "boolean"
+},
+"statementActionDate": {
+"format": "date",
+"type": "string"
+},
+"statementType": {
+"type": "string"
+},
+"updated_at": {
+"format": "date-time",
+"readOnly": true,
+"type": "string"
+}
+},
+"type": "object"
+},
+"PscWithIdentificationFiling": {
+"properties": {
+"address": {
+"$ref": "#/definitions/Address"
+},
+"addressSameAsRegisteredOfficeAddress": {
+"type": "boolean"
+},
+"ceasedOn": {
+"format": "date",
+"type": "string"
+},
+"created_at": {
+"format": "date-time",
+"readOnly": true,
+"type": "string"
+},
+"etag": {
+"type": "string"
+},
+"id": {
+"readOnly": true,
+"type": "string"
+},
+"identification": {
+"$ref": "#/definitions/Identification"
+},
+"kind": {
+"type": "string"
+},
+"links": {
+"$ref": "#/definitions/Links"
+},
+"name": {
+"type": "string"
+},
+"naturesOfControl": {
+"items": {
+"type": "string"
+},
+"type": "array"
+},
+"notifiedOn": {
+"format": "date",
+"type": "string"
+},
+"referenceEtag": {
+"type": "string"
+},
+"referencePscId": {
+"type": "string"
+},
+"registerEntryDate": {
+"format": "date",
+"type": "string"
+},
+"statementActionDate": {
+"format": "date",
+"type": "string"
+},
+"statementType": {
+"type": "string"
+},
+"updated_at": {
+"format": "date-time",
+"readOnly": true,
+"type": "string"
+}
+},
+"type": "object"
+},
+"ValidationStatusError": {
+"properties": {
+"error": {
+"type": "string"
+},
+"location": {
+"type": "string"
+},
+"location_type": {
+"type": "string"
+},
+"type": {
+"type": "string"
+}
+},
+"type": "object"
+},
+"ValidationStatusResponse": {
+"properties": {
+"errors": {
+"items": {
+"$ref": "#/definitions/ValidationStatusError"
+},
+"type": "array"
+},
+"is_valid": {
+"type": "boolean"
+}
+},
+"type": "object"
+}
+},
+"x-components": {}
+}

--- a/docs/spec-v2.0.json
+++ b/docs/spec-v2.0.json
@@ -6,7 +6,7 @@
   ],
   "info": {
     "title": "PSC Filing API (Private)",
-    "version": "0.5",
+    "version": "0.6",
     "description": "An API that allows clients to submit PSC filings. Currently for PSC07 (Cease a PSC) only."
   },
   "host": "api.chs.local:4001",
@@ -309,7 +309,7 @@
   },
   "responses": {
     "Conflict": {
-      "description": "The request could not be fulfilled because all of the following conditions were not satisfied:\n* The company type **must** be any of:\n\t- `private-unlimited`\n\t- `ltd`\n\t- `plc`\n\t- `old-public-company`\n\t- `private-limited-guarant-nsc-limited-exemption`\n\t- `private-limited-guarant-nsc`\n\t- `private-unlimited-nsc`\n\t- `private-limited-shares-section-30-exemption`\n* The company status **must not** be any of:\n\t- `dissolved`\n\t- `converted-closed`\n* The company **must not** have any PSCs whose details are protected.",
+      "description": "The request could not be fulfilled because all of the following conditions were not satisfied:\n\n* The company type **must** be any of:\n\t- `private-unlimited`\n\t- `ltd`\n\t- `plc`\n\t- `old-public-company`\n\t- `private-limited-guarant-nsc-limited-exemption`\n\t- `private-limited-guarant-nsc`\n\t- `private-unlimited-nsc`\n\t- `private-limited-shares-section-30-exemption`\n* The company status **must not** be any of:\n\t- `dissolved`\n\t- `converted-closed`\n* The company **must not** have any PSCs whose details are protected.",
       "schema": {
         "$ref": "#/definitions/ConflictErrors"
       }

--- a/docs/spec-v2.0.json
+++ b/docs/spec-v2.0.json
@@ -1,9 +1,13 @@
 {
   "swagger": "2.0",
+  "x-sortMethodsBy": [
+    "operation",
+    "path"
+  ],
   "info": {
     "title": "PSC Filing API (Private)",
-    "version": "0.3",
-    "description": "Private specification for the PSC Filings service (currently for PSC07 [Cease a PSC] only).\nIncludes:\n * Public paths for use by third party software filers and CHS, and\n* Private paths for CHS internal users only, and\n* Data models for any of PSC01 to PSC09.\n\n---\n### NOTE\n**Only PSC07 is currently supported**. It requires only the following properties:\n* `ceased_on`\n* `register_entry-date`\n* `reference_psc_id`\n* `reference_etag`"
+    "version": "0.4",
+    "description": "Private specification for the PSC Filings service (currently for PSC07 [Cease a PSC] only).\nIncludes:\n * Public paths for use by third party software filers and CHS, and\n* Private paths for CHS internal users only, and\n* Data models for PSC07 and associated responses.\n\n---\n### NOTE\nFor a PSC07 filing to be valid, at time of closing the transaction the following properties are required:\n* `ceased_on`\n* `register_entry-date`\n* `reference_psc_id`\n* `reference_etag`\n\nThose properties are optional for the 'create' requests and may be added later using an 'update' request."
   },
   "host": "api.chs.local:4001",
   "basePath": "/",
@@ -12,7 +16,10 @@
   ],
   "security": [
     {
-      "OAuth2-ERIC": []
+      "oauth2": [
+        "https://api.company-information.service.gov.uk/company/*/persons-with-significant-control.delete",
+        "https://account.companieshouse.gov.uk/user/profile.read"
+      ]
     }
   ],
   "tags": [
@@ -22,96 +29,10 @@
     }
   ],
   "paths": {
-    "/private/transactions/{transactionId}/persons-with-significant-control/{pscType}/{filingResourceId}/filings": {
-      "get": {
-        "description": "Provide enhanced filing data needed to submit the PSC filing to CHIPS. For internal use by the filing resource handler service.",
-        "produces": [
-          "application/json"
-        ],
-        "security": [
-          {
-            "API-Key-ERIC": []
-          }
-        ],
-        "parameters": [
-          {
-            "$ref": "#/parameters/transactionId"
-          },
-          {
-            "$ref": "#/parameters/pscType"
-          },
-          {
-            "$ref": "#/parameters/filingResourceId"
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/FilingData"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden \n* The authorization identity type must equal '`key`' and \n* The authenticated user account must have internal user privileges and\n* The request must have an API key that has internal application privileges."
-          },
-          "404": {
-              "$ref": "#/responses/FilingNotFound"
-          },
-          "409": {
-            "$ref": "#/responses/Conflict"
-          },
-          "500": {
-            "description": "#### Internal Server Error\nThe request could not be fulfilled due to:\n* The filing resource transaction is not Closed or\n* an internal error."
-          }
-        },
-        "tags": [
-          "pscFiling"
-        ],
-        "operationId": "getFilingsData",
-        "x-operationName": "provide filings data"
-      }
-    },
-    "/transactions/{transactionId}/persons-with-significant-control/{filingResourceId}/validation_status": {
-      "get": {
-        "description": "Check the validity of a PSC filing. When a request is made to the Transaction Service to close the filing resource transaction, that service makes a request to this path. If valid, the Transaction Service closes the transaction and marks it for processing.",
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/parameters/transactionId"
-          },
-          {
-            "$ref": "#/parameters/filingResourceId"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "#### OK\nThe validation operation completed successfully. The `is_valid` property in the response body indicates the validity of the filing. The `errors` property in the response body contains details of any validation errors.\n#### Examples:\n<table><tr><td>\n\n**is_valid**\n\n</td><td>\n\n**errors**\n\n</td></tr><tr><td>true</td><td>\n\n`[]`\n\n</td></tr><tr><td>false</td><td>\n\n```\n[\n\t{\n\t\t\"error\": \"PSC register entry date must be on or after the date the PSC was ceased\",\n\t\t\"location\": \"$.register_entry_date\",\n\t\t\"type\": \"ch:validation\",\n\t\t\"location_type\": \"json-path\"\n\t}\n]\n```\n\n</td></tr></table>",
-            "schema": {
-              "$ref": "#/definitions/ValidationStatus"
-            }
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "404": {
-            "$ref": "#/responses/FilingNotFound"
-          },
-          "500": {
-            "$ref": "#/responses/InternalServerError"
-          }
-        },
-        "tags": [
-          "pscFiling"
-        ],
-        "operationId": "validateFiling",
-        "x-operationName": "validate filing"
-      }
-    },
-    "/transactions/{transactionId}/persons-with-significant-control/individual": {
+    "/transactions/{transactionId}/persons-with-significant-control/{pscType}": {
       "post": {
-        "summary": "Create a filing for an Individual PSC.",
+        "summary": "Create a PSC filing resource",
+        "description": "Create a PSC filing of the specified type.",
         "consumes": [
           "application/json"
         ],
@@ -123,12 +44,10 @@
             "$ref": "#/parameters/transactionId"
           },
           {
-            "in": "body",
-            "name": "filingBody",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/PscIndividual"
-            }
+            "$ref": "#/parameters/pscType"
+          },
+          {
+            "$ref": "#/parameters/pscFilingDetails"
           }
         ],
         "responses": {
@@ -158,116 +77,13 @@
           "pscFiling"
         ],
         "operationId": "createIndividualPscFiling",
-        "x-operationName": "create individual filing"
-      }
-    },
-    "/transactions/{transactionId}/persons-with-significant-control/corporate-entity": {
-      "post": {
-        "description": "Create a filing for an Corporate Entity PSC.",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/parameters/transactionId"
-          },
-          {
-            "in": "body",
-            "name": "filingBody",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/PscWithIdentification"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "$ref": "#/responses/PscCorporateEntityFilingCreated"
-          },
-          "400": {
-            "$ref": "#/responses/CreateFilingBadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotCreated"
-          },
-          "409": {
-            "$ref": "#/responses/Conflict"
-          },
-          "500": {
-            "$ref": "#/responses/InternalServerError"
-          }
-        },
-        "tags": [
-          "pscFiling"
-        ],
-        "operationId": "createCorporateEntityPscFiling",
-        "x-operationName": "create corporate entity filing"
-      }
-    },
-    "/transactions/{transactionId}/persons-with-significant-control/legal-person": {
-      "post": {
-        "description": "Create a filing for an Legal Person PSC.",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/parameters/transactionId"
-          },
-          {
-            "in": "body",
-            "name": "filingBody",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/PscWithIdentification"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "$ref": "#/responses/PscLegalPersonFilingCreated"
-          },
-          "400": {
-            "$ref": "#/responses/CreateFilingBadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotCreated"
-          },
-          "409": {
-            "$ref": "#/responses/Conflict"
-          },
-          "500": {
-            "$ref": "#/responses/InternalServerError"
-          }
-        },
-        "tags": [
-          "pscFiling"
-        ],
-        "operationId": "createLegalPersonPscFiling",
-        "x-operationName": "create legal person filing"
+        "x-operationName": "create filing"
       }
     },
     "/transactions/{transactionId}/persons-with-significant-control/{pscType}/{filingResourceId}": {
       "get": {
-        "description": "Fetch a PSC filing resource.",
+        "summary": "Get this PSC filing resource details",
+        "description": "Get this PSC filing resource details.",
         "produces": [
           "application/json"
         ],
@@ -300,10 +116,11 @@
           "pscFiling"
         ],
         "operationId": "getFilingForReview",
-        "x-operationName": "get filing for review"
+        "x-operationName": "get filing"
       },
       "patch": {
-        "description": "Update permitted properties of a PSC filing resource. Supports adding, replacing or removing properties specified in the request body &mdash; see [RFC7396](https://www.rfc-editor.org/rfc/rfc7396) for details.\n### NOTE\n Certain properties of the filing are **read only**. If present in the request body they will be **ignored**, and `updated_at` will be modified automatically.\n* `id`\n* `created_at`\n* `updated_at` (modified automatically)\n* `links`\n",
+        "summary": "Update this PSC filing resource",
+        "description": "Update permitted properties of a PSC filing resource. Supports adding, replacing or removing properties specified in the request body &mdash; see [RFC7396](https://www.rfc-editor.org/rfc/rfc7396) for details.\n### NOTE\n Certain filing resource properties are **read only** and will be **ignored** if present in the request:\n* `id`\n* `created_at`\n* `updated_at` (modified automatically if the request succeeds)\n* `links`\n",
         "consumes": [
           "application/merge-patch+json"
         ],
@@ -353,6 +170,95 @@
         "operationId": "updateFiling",
         "x-operationName": "update filing"
       }
+    },
+    "/transactions/{transactionId}/persons-with-significant-control/{filingResourceId}/validation_status": {
+      "get": {
+        "summary": "Check this filing resource for completeness",
+        "description": "Check the validity and completeness of a PSC filing. Primarily for use by the Transaction Service when requested to close the filing resource transaction.",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/transactionId"
+          },
+          {
+            "$ref": "#/parameters/filingResourceId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The validation operation completed successfully. The `is_valid` property in the response body indicates the validity of the filing. The `errors` property in the response body contains details of any validation errors.\n#### Examples:\n<table><tr><td>\n\n**is_valid**\n\n</td><td>\n\n**errors**\n\n</td></tr><tr><td>true</td><td>\n\n`[]`\n\n</td></tr><tr><td>false</td><td>\n\n```\n[\n\t{\n\t\t\"error\": \"PSC register entry date must be on or after the date the PSC was ceased\",\n\t\t\"location\": \"$.register_entry_date\",\n\t\t\"type\": \"ch:validation\",\n\t\t\"location_type\": \"json-path\"\n\t}\n]\n```\n\n</td></tr></table>",
+            "schema": {
+              "$ref": "#/definitions/ValidationStatus"
+            }
+          },
+          "401": {
+            "$ref": "#/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/responses/FilingNotFound"
+          },
+          "500": {
+            "$ref": "#/responses/InternalServerError"
+          }
+        },
+        "tags": [
+          "pscFiling"
+        ],
+        "operationId": "validateFiling",
+        "x-operationName": "validate filing"
+      }
+    },
+    "/private/transactions/{transactionId}/persons-with-significant-control/{pscType}/{filingResourceId}/filings": {
+      "get": {
+        "summary": "Get CHIPS-compatible details of this filing resource",
+        "description": "Get the CHIPS-compatible details of this filing resource. For internal use by the filing resource handler service.",
+        "produces": [
+          "application/json"
+        ],
+        "security": [
+          {
+            "api_key": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/transactionId"
+          },
+          {
+            "$ref": "#/parameters/pscType"
+          },
+          {
+            "$ref": "#/parameters/filingResourceId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/FilingData"
+          },
+          "401": {
+            "$ref": "#/responses/Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden \n* The authorization identity type must equal '`key`' and \n* The authenticated user account must have internal user privileges and\n* The request must have an API key that has internal application privileges."
+          },
+          "404": {
+              "$ref": "#/responses/FilingNotFound"
+          },
+          "409": {
+            "$ref": "#/responses/Conflict"
+          },
+          "500": {
+            "description": "The request could not be fulfilled due to:\n* The filing resource transaction is not Closed or\n* an internal error."
+          }
+        },
+        "tags": [
+          "pscFiling"
+        ],
+        "operationId": "getFilingsData",
+        "x-operationName": "get filing for CHIPS"
+      }
     }
   },
   "parameters": {
@@ -361,7 +267,7 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "description": "The current open transaction ID for the filing resource",
+      "description": "The transaction that this PSC filing is applied to",
       "x-example": "142481-538116-714607"
     },
     "pscType": {
@@ -399,11 +305,20 @@
           "register_entry_date": "2023-02-11"
         }
       }
+    },
+    "pscFilingDetails": {
+      "in": "body",
+      "name": "pscFilingDetails",
+      "required": true,
+      "description": "The PSC filing details",
+      "schema": {
+        "$ref": "#/definitions/PscFiling"
+      }
     }
   },
   "responses": {
     "Conflict": {
-      "description": "#### Conflict\nThe request could not be fulfilled due to any of:\n* The company's type is not one that allows the request:\n\t- `private-unlimited`\n\t- `ltd`\n\t- `plc`\n\t- `old-public-company`\n\t- `private-limited-guarant-nsc-limited-exemption`\n\t- `private-limited-guarant-nsc`\n\t- `private-unlimited-nsc`\n\t- `private-limited-shares-section-30-exemption`\n* The company's status is one that forbids the request:\n\t- `dissolved`\n\t- `converted-closed`\n* The company has one or more PSCs whose details are protected.",
+      "description": "The request could not be fulfilled due to any of:\n* The company's type is not one that allows the request:\n\t- `private-unlimited`\n\t- `ltd`\n\t- `plc`\n\t- `old-public-company`\n\t- `private-limited-guarant-nsc-limited-exemption`\n\t- `private-limited-guarant-nsc`\n\t- `private-unlimited-nsc`\n\t- `private-limited-shares-section-30-exemption`\n* The company's status is one that forbids the request:\n\t- `dissolved`\n\t- `converted-closed`\n* The company has one or more PSCs whose details are protected.",
       "schema": {
         "$ref": "#/definitions/ApiErrors"
       },
@@ -421,7 +336,7 @@
       }
     },
     "CreateFilingBadRequest": {
-      "description": "#### Bad Request\nThe request to create a filing resource contains bad data.",
+      "description": "The request to create a filing resource contains bad data.",
       "examples": {
         "application/json": {
           "errors": [
@@ -439,9 +354,9 @@
       }
     },
     "FilingFound": {
-      "description": "#### OK\nThe response body provides the representation of the found filing resource.",
+      "description": "The response body provides the details of the found filing resource.",
       "schema": {
-        "$ref": "#/definitions/PscIndividualFiling"
+        "$ref": "#/definitions/PscFilingResource"
       },
       "examples": {
         "application/json": {
@@ -452,7 +367,7 @@
           },
           "reference_etag": "8cb9d4c9ba82059ff01ed638105bc41c1bc4db40",
           "reference_psc_id": "1kdaTltWeaP1EB70SSD9SLmiK5Y",
-          "register_entry_date": "2022-10-15",
+          "register_entry_date": "2022-08-30",
           "id": "6470946f9f4c3f6c1ed25a19",
           "created_at": "2023-05-26T11:13:51.787Z",
           "updated_at": "2023-05-26T11:13:51.787Z"
@@ -460,7 +375,7 @@
       }
     },
     "FilingNotFound": {
-      "description": "#### Not Found\nA filing having the specified combination of transaction ID, filing resource ID and PSC type could not be found.",
+      "description": "A filing with the specified combination of transaction ID, filing resource ID and PSC type could not be found.",
       "schema": {
         "$ref": "#/definitions/ApiErrors"
       },
@@ -481,10 +396,10 @@
       }
     },
     "FilingData": {
-      "description": "#### OK\n",
+      "description": "The CHIPS-compatible details of this filing resource.",
       "schema": {
         "items": {
-          "$ref": "#/definitions/FilingApi"
+          "$ref": "#/definitions/chipsFilingResource"
         },
         "type": "array",
         "example": [
@@ -494,20 +409,20 @@
               "first_name": "Random",
               "other_forenames": "Notreal",
               "last_name": "Person",
-              "ceased_on": "2022-08-30",
-              "register_entry_date": "2022-10-15"
+              "ceased_on": "2022-08-29",
+              "register_entry_date": "2022-08-30"
             },
-            "description": "(PSC07) Notice of ceasing to be a Person of Significant Control for Mr Random Notreal Person on 30 August 2022",
+            "description": "(PSC07) Notice of ceasing to be a Person of Significant Control for Mr Random Notreal Person on 29 August 2022",
             "kind": "psc-filing#cessation#individual"
           }
         ]
       }
     },
     "Forbidden": {
-      "description": "#### Forbidden\nThe filing resource transaction is not in an open state, or the operation is otherwise not allowed."
+      "description": "The filing resource transaction is not in an open state, or the operation is otherwise not allowed."
     },
     "InternalServerError": {
-      "description": "#### Internal Server Error\nThe request could not be fulfilled due to an internal error.",
+      "description": "The request could not be fulfilled due to an internal error.",
       "schema": {
         "$ref": "#/definitions/ApiErrors"
       },
@@ -525,36 +440,15 @@
       }
     },
     "NotCreated": {
-      "description": "Not Found\nThe filing resource could not be created due to any of: \n* The transaction ID in the request path does not match an existing transaction or\n* The PSC type in the last segment of the path does not match one of the accepted values:\n\t* `individual`\n\t* `corporate-entity`\n\t* `legal-person`"
+      "description": "The filing resource could not be created due to any of: \n* The transaction ID in the request path does not match an existing transaction or\n* The PSC type in the last segment of the path does not match one of the accepted values:\n\t* `individual`\n\t* `corporate-entity`\n\t* `legal-person`"
     },
     "NotFound": {
-      "description": "Not Found\nA filing having the specified combination of transaction ID, filing resource ID and PSC type could not be found."
-    },
-    "PscCorporateEntityFilingCreated": {
-      "description": "#### Created\nFor convenience the response body provides the representation of the created filing resource.",
-      "schema": {
-        "$ref": "#/definitions/PscWithIdentificationFiling"
-      },
-      "examples": {
-        "application/json": {
-          "ceased_on": "2023-04-19",
-          "links": {
-            "self": "/transactions/098781-975316-819849/persons-with-significant-control/corporate-entity/64410d94aa51447dcf469570",
-            "validation_status": "/transactions/098781-975316-819849/persons-with-significant-control/64410d94aa51447dcf469570/validation_status"
-          },
-          "reference_etag": "4e5fda8b2b6dba10862965ee34d80915d7b48266",
-          "reference_psc_id": "fhhMkjhxbWGc0juOZvDhNcbFn8o",
-          "register_entry_date": "2023-04-19",
-          "id": "64410d94aa51447dcf469570",
-          "created_at": "2023-04-20T10:01:56.129Z",
-          "updated_at": "2023-04-20T10:01:56.129Z"
-        }
-      }
+      "description": "A filing with the specified combination of transaction ID, filing resource ID and PSC type could not be found."
     },
     "PscIndividualFilingCreated": {
-      "description": "#### Created\nFor convenience the response body provides the representation of the created filing resource.",
+      "description": "For convenience the response body contains details of the created filing resource.",
       "schema": {
-        "$ref": "#/definitions/PscIndividualFiling"
+        "$ref": "#/definitions/PscFilingResource"
       },
       "examples": {
         "application/json": {
@@ -565,37 +459,17 @@
           },
           "reference_etag": "8cb9d4c9ba82059ff01ed638105bc41c1bc4db40",
           "reference_psc_id": "1kdaTltWeaP1EB70SSD9SLmiK5Y",
-          "register_entry_date": "2022-10-15",
+          "register_entry_date": "2022-08-30",
           "id": "6470946f9f4c3f6c1ed25a19",
           "created_at": "2023-05-26T11:13:51.787Z",
           "updated_at": "2023-05-26T11:13:51.787Z"
         }
       }
     },
-    "PscLegalPersonFilingCreated": {
-      "description": "#### Created\nFor convenience the response body provides the representation of the created filing resource.",
-      "schema": {
-        "$ref": "#/definitions/PscWithIdentificationFiling"
-      },
-      "examples": {
-        "application/json": {
-          "links": {
-            "self": "/transactions/116642-036916-819881/persons-with-significant-control/legal-person/64411a2faa51447dcf469693",
-            "validation_status": "/transactions/116642-036916-819881/persons-with-significant-control/64411a2faa51447dcf469693/validation_status"
-          },
-          "reference_etag": "b1786d54fd49e0cd21a3bf402819370f35d24ad1",
-          "reference_psc_id": "OTk2OTA1NDg4OExJSzBNUjFR",
-          "register_entry_date": "2023-04-19T23:00:00.000Z",
-          "id": "64411a2faa51447dcf469693",
-          "created_at": "2023-04-20T10:55:43.695Z",
-          "updated_at": "2023-04-20T10:55:43.695Z"
-        }
-      }
-    },
     "PscFilingUpdated": {
-      "description": "#### OK\nFor convenience the response body provides the representation of the updated filing resource.",
+      "description": "For convenience the response body provides the details of the updated filing resource.",
       "schema": {
-        "$ref": "#/definitions/PscWithIdentificationFiling"
+        "$ref": "#/definitions/PscFilingResource"
       },
       "examples": {
         "application/json": {
@@ -614,7 +488,7 @@
       }
     },
     "Unauthorized": {
-      "description": "#### Unauthorized\nRequest credentials/authorization are invalid or missing.",
+      "description": "Request credentials/authorization are invalid or missing.",
       "schema": {
         "type": "object",
         "title": "UnauthorizedResponse",
@@ -633,7 +507,7 @@
       }
     },
     "UpdateFilingBadRequest": {
-      "description": "#### Bad Request\nThe request to update a filing resource contains bad data.",
+      "description": "The request to update a filing resource contains bad data.",
       "examples": {
         "application/json": {
           "errors": [
@@ -652,56 +526,23 @@
     }
   },
   "securityDefinitions": {
-    "OAuth2-ERIC": {
+    "oauth2": {
       "type": "oauth2",
       "flow": "accessCode",
       "authorizationUrl": "http://account.chs.local/oauth2/authorise",
       "tokenUrl": "http://account.chs.local/oauth2/token",
       "scopes": {
-        "https://account.companieshouse.gov.uk/user/profile.read": "Grants permission to read CHS User profile.",
-        "https://api.company-information.service.gov.uk/company/{company_number}/persons-with-significant-control.delete": "Grants permission to cease a PSC belonging to this company."
+        "https://api.company-information.service.gov.uk/company/*/persons-with-significant-control.delete": "Grants permission to cease a PSC belonging to this company.",
+        "https://account.companieshouse.gov.uk/user/profile.read": "Grants permission to read the CHS User profile."
       }
     },
-    "API-Key-ERIC": {
+    "api_key": {
       "type": "apiKey",
       "name": "api_key",
       "in": "header"
     }
   },
   "definitions": {
-    "Address": {
-      "properties": {
-        "address_line_1": {
-          "type": "string"
-        },
-        "address_line_2": {
-          "type": "string"
-        },
-        "care_of": {
-          "type": "string"
-        },
-        "country": {
-          "type": "string"
-        },
-        "locality": {
-          "type": "string"
-        },
-        "po_box": {
-          "type": "string"
-        },
-        "postal_code": {
-          "type": "string"
-        },
-        "premises": {
-          "type": "string"
-        },
-        "region": {
-          "type": "string"
-        }
-      },
-      "type": "object",
-      "title": "Address"
-    },
     "ApiError": {
       "properties": {
         "error": {
@@ -739,25 +580,7 @@
       "type": "object",
       "title": "ApiErrors"
     },
-    "Date": {
-      "properties": {
-        "day": {
-          "format": "int32",
-          "type": "integer"
-        },
-        "month": {
-          "format": "int32",
-          "type": "integer"
-        },
-        "year": {
-          "format": "int32",
-          "type": "integer"
-        }
-      },
-      "type": "object",
-      "title": "Date"
-    },
-    "FilingApi": {
+    "chipsFilingResource": {
       "properties": {
         "data": {
           "additionalProperties": {
@@ -782,28 +605,8 @@
         }
       },
       "type": "object",
-      "title": "FilingApi"
-    },
-    "Identification": {
-      "properties": {
-        "country_registered": {
-          "type": "string"
-        },
-        "legal_authority": {
-          "type": "string"
-        },
-        "legal_form": {
-          "type": "string"
-        },
-        "place_registered": {
-          "type": "string"
-        },
-        "registration_number": {
-          "type": "string"
-        }
-      },
-      "type": "object",
-      "title": "Identification"
+      "title": "chipsFilingResource",
+      "description": "CHIPS-compatible PSC filing details"
     },
     "Links": {
       "properties": {
@@ -819,285 +622,47 @@
       "type": "object",
       "title": "Links"
     },
-    "NameElements": {
+    "PscFiling": {
       "properties": {
-        "forename": {
-          "type": "string"
-        },
-        "other_forenames": {
-          "type": "string"
-        },
-        "surname": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        }
-      },
-      "type": "object",
-      "title": "NameElements"
-    },
-    "PscIndividual": {
-      "properties": {
-        "address": {
-          "$ref": "#/definitions/Address"
-        },
-        "address_same_as_registered_office_address": {
-          "type": "boolean"
-        },
         "ceased_on": {
           "format": "date",
-          "type": "string"
-        },
-        "country_of_residence": {
-          "type": "string"
-        },
-        "date_of_birth": {
-          "$ref": "#/definitions/Date"
-        },
-        "name_elements": {
-          "$ref": "#/definitions/NameElements"
-        },
-        "nationality": {
-          "type": "string"
-        },
-        "natures_of_control": {
-          "items": {
-            "type": "string",
-            "enum": [
-              "ownership-of-shares-25-to-50-percent",
-              "ownership-of-shares-50-to-75-percent",
-              "ownership-of-shares-75-to-100-percent",
-              "ownership-of-shares-25-to-50-percent-as-trust",
-              "ownership-of-shares-50-to-75-percent-as-trust",
-              "ownership-of-shares-75-to-100-percent-as-trust",
-              "ownership-of-shares-25-to-50-percent-as-firm",
-              "ownership-of-shares-50-to-75-percent-as-firm",
-              "ownership-of-shares-75-to-100-percent-as-firm",
-              "ownership-of-shares-more-than-25-percent-registered-overseas-entity",
-              "ownership-of-shares-more-than-25-percent-as-trust-registered-overseas-entity",
-              "ownership-of-shares-more-than-25-percent-as-firm-registered-overseas-entity",
-              "voting-rights-25-to-50-percent",
-              "voting-rights-50-to-75-percent",
-              "voting-rights-75-to-100-percent",
-              "voting-rights-25-to-50-percent-as-trust",
-              "voting-rights-50-to-75-percent-as-trust",
-              "voting-rights-75-to-100-percent-as-trust",
-              "voting-rights-25-to-50-percent-as-firm",
-              "voting-rights-50-to-75-percent-as-firm",
-              "voting-rights-75-to-100-percent-as-firm",
-              "voting-rights-more-than-25-percent-registered-overseas-entity",
-              "voting-rights-more-than-25-percent-as-trust-registered-overseas-entity",
-              "voting-rights-more-than-25-percent-as-firm-registered-overseas-entity",
-              "right-to-appoint-and-remove-directors",
-              "right-to-appoint-and-remove-directors-as-trust",
-              "right-to-appoint-and-remove-directors-as-firm",
-              "significant-influence-or-control",
-              "significant-influence-or-control-as-trust",
-              "significant-influence-or-control-as-firm",
-              "right-to-share-surplus-assets-25-to-50-percent-limited-liability-partnership",
-              "right-to-share-surplus-assets-50-to-75-percent-limited-liability-partnership",
-              "right-to-share-surplus-assets-75-to-100-percent-limited-liability-partnership",
-              "right-to-share-surplus-assets-25-to-50-percent-as-trust-limited-liability-partnership",
-              "right-to-share-surplus-assets-50-to-75-percent-as-trust-limited-liability-partnership",
-              "right-to-share-surplus-assets-75-to-100-percent-as-trust-limited-liability-partnership",
-              "right-to-share-surplus-assets-25-to-50-percent-as-firm-limited-liability-partnership",
-              "right-to-share-surplus-assets-50-to-75-percent-as-firm-limited-liability-partnership",
-              "right-to-share-surplus-assets-75-to-100-percent-as-firm-limited-liability-partnership",
-              "voting-rights-25-to-50-percent-limited-liability-partnership",
-              "voting-rights-50-to-75-percent-limited-liability-partnership",
-              "voting-rights-75-to-100-percent-limited-liability-partnership",
-              "voting-rights-25-to-50-percent-as-trust-limited-liability-partnership",
-              "voting-rights-50-to-75-percent-as-trust-limited-liability-partnership",
-              "voting-rights-75-to-100-percent-as-trust-limited-liability-partnership",
-              "voting-rights-25-to-50-percent-as-firm-limited-liability-partnership",
-              "voting-rights-50-to-75-percent-as-firm-limited-liability-partnership",
-              "voting-rights-75-to-100-percent-as-firm-limited-liability-partnership",
-              "right-to-appoint-and-remove-members-limited-liability-partnership",
-              "right-to-appoint-and-remove-members-as-trust-limited-liability-partnership",
-              "right-to-appoint-and-remove-members-as-firm-limited-liability-partnership",
-              "significant-influence-or-control-limited-liability-partnership",
-              "significant-influence-or-control-as-trust-limited-liability-partnership",
-              "significant-influence-or-control-as-firm-limited-liability-partnership",
-              "significant-influence-or-control-registered-overseas-entity",
-              "significant-influence-or-control-as-trust-registered-overseas-entity",
-              "significant-influence-or-control-as-firm-registered-overseas-entity",
-              "part-right-to-share-surplus-assets-25-to-50-percent",
-              "part-right-to-share-surplus-assets-50-to-75-percent",
-              "part-right-to-share-surplus-assets-75-to-100-percent",
-              "part-right-to-share-surplus-assets-25-to-50-percent-as-trust",
-              "part-right-to-share-surplus-assets-50-to-75-percent-as-trust",
-              "part-right-to-share-surplus-assets-75-to-100-percent-as-trust",
-              "part-right-to-share-surplus-assets-25-to-50-percent-as-firm",
-              "part-right-to-share-surplus-assets-50-to-75-percent-as-firm",
-              "part-right-to-share-surplus-assets-75-to-100-percent-as-firm",
-              "right-to-appoint-and-remove-person",
-              "right-to-appoint-and-remove-person-as-firm",
-              "right-to-appoint-and-remove-person-as-trust",
-              "right-to-appoint-and-remove-directors-registered-overseas-entity",
-              "right-to-appoint-and-remove-directors-as-trust-registered-overseas-entity",
-              "right-to-appoint-and-remove-directors-as-firm-registered-overseas-entity"
-            ]
-          },
-          "type": "array"
-        },
-        "notified_on": {
-          "format": "date",
-          "type": "string"
+          "type": "string",
+          "example": "2022-08-29"
         },
         "reference_etag": {
-          "type": "string"
+          "type": "string",
+          "example": "8cb9d4c9ba82059ff01ed638105bc41c1bc4db40"
         },
         "reference_psc_id": {
-          "type": "string"
+          "type": "string",
+          "example": "1kdaTltWeaP1EB70SSD9SLmiK5Y"
         },
         "register_entry_date": {
           "format": "date",
-          "type": "string"
-        },
-        "residential_address": {
-          "$ref": "#/definitions/Address"
-        },
-        "residential_address_same_as_correspondence_address": {
-          "type": "boolean"
-        },
-        "statementActionDate": {
-          "format": "date",
-          "type": "string"
-        },
-        "statementType": {
-          "type": "string"
+          "type": "string",
+          "example": "2022-08-30"
         }
       },
       "type": "object",
-      "title": "PscIndividual"
+      "title": "PscFiling"
     },
-    "PscIndividualFiling": {
+    "PscFilingResource": {
       "properties": {
-        "address": {
-          "$ref": "#/definitions/Address"
-        },
-        "address_same_as_registered_office_address": {
-          "type": "boolean"
-        },
         "ceased_on": {
           "format": "date",
           "type": "string"
         },
-        "country_of_residence": {
-          "type": "string"
-        },
         "created_at": {
+          "readOnly": true,
           "format": "date-time",
-          "readOnly": true,
-          "type": "string"
-        },
-        "date_of_birth": {
-          "$ref": "#/definitions/Date"
-        },
-        "etag": {
-          "readOnly": true,
           "type": "string"
         },
         "id": {
           "readOnly": true,
           "type": "string"
         },
-        "kind": {
-          "type": "string"
-        },
         "links": {
           "$ref": "#/definitions/Links"
-        },
-        "name_elements": {
-          "$ref": "#/definitions/NameElements"
-        },
-        "nationality": {
-          "type": "string"
-        },
-        "natures_of_control": {
-          "items": {
-            "type": "string",
-            "enum": [
-              "ownership-of-shares-25-to-50-percent",
-              "ownership-of-shares-50-to-75-percent",
-              "ownership-of-shares-75-to-100-percent",
-              "ownership-of-shares-25-to-50-percent-as-trust",
-              "ownership-of-shares-50-to-75-percent-as-trust",
-              "ownership-of-shares-75-to-100-percent-as-trust",
-              "ownership-of-shares-25-to-50-percent-as-firm",
-              "ownership-of-shares-50-to-75-percent-as-firm",
-              "ownership-of-shares-75-to-100-percent-as-firm",
-              "ownership-of-shares-more-than-25-percent-registered-overseas-entity",
-              "ownership-of-shares-more-than-25-percent-as-trust-registered-overseas-entity",
-              "ownership-of-shares-more-than-25-percent-as-firm-registered-overseas-entity",
-              "voting-rights-25-to-50-percent",
-              "voting-rights-50-to-75-percent",
-              "voting-rights-75-to-100-percent",
-              "voting-rights-25-to-50-percent-as-trust",
-              "voting-rights-50-to-75-percent-as-trust",
-              "voting-rights-75-to-100-percent-as-trust",
-              "voting-rights-25-to-50-percent-as-firm",
-              "voting-rights-50-to-75-percent-as-firm",
-              "voting-rights-75-to-100-percent-as-firm",
-              "voting-rights-more-than-25-percent-registered-overseas-entity",
-              "voting-rights-more-than-25-percent-as-trust-registered-overseas-entity",
-              "voting-rights-more-than-25-percent-as-firm-registered-overseas-entity",
-              "right-to-appoint-and-remove-directors",
-              "right-to-appoint-and-remove-directors-as-trust",
-              "right-to-appoint-and-remove-directors-as-firm",
-              "significant-influence-or-control",
-              "significant-influence-or-control-as-trust",
-              "significant-influence-or-control-as-firm",
-              "right-to-share-surplus-assets-25-to-50-percent-limited-liability-partnership",
-              "right-to-share-surplus-assets-50-to-75-percent-limited-liability-partnership",
-              "right-to-share-surplus-assets-75-to-100-percent-limited-liability-partnership",
-              "right-to-share-surplus-assets-25-to-50-percent-as-trust-limited-liability-partnership",
-              "right-to-share-surplus-assets-50-to-75-percent-as-trust-limited-liability-partnership",
-              "right-to-share-surplus-assets-75-to-100-percent-as-trust-limited-liability-partnership",
-              "right-to-share-surplus-assets-25-to-50-percent-as-firm-limited-liability-partnership",
-              "right-to-share-surplus-assets-50-to-75-percent-as-firm-limited-liability-partnership",
-              "right-to-share-surplus-assets-75-to-100-percent-as-firm-limited-liability-partnership",
-              "voting-rights-25-to-50-percent-limited-liability-partnership",
-              "voting-rights-50-to-75-percent-limited-liability-partnership",
-              "voting-rights-75-to-100-percent-limited-liability-partnership",
-              "voting-rights-25-to-50-percent-as-trust-limited-liability-partnership",
-              "voting-rights-50-to-75-percent-as-trust-limited-liability-partnership",
-              "voting-rights-75-to-100-percent-as-trust-limited-liability-partnership",
-              "voting-rights-25-to-50-percent-as-firm-limited-liability-partnership",
-              "voting-rights-50-to-75-percent-as-firm-limited-liability-partnership",
-              "voting-rights-75-to-100-percent-as-firm-limited-liability-partnership",
-              "right-to-appoint-and-remove-members-limited-liability-partnership",
-              "right-to-appoint-and-remove-members-as-trust-limited-liability-partnership",
-              "right-to-appoint-and-remove-members-as-firm-limited-liability-partnership",
-              "significant-influence-or-control-limited-liability-partnership",
-              "significant-influence-or-control-as-trust-limited-liability-partnership",
-              "significant-influence-or-control-as-firm-limited-liability-partnership",
-              "significant-influence-or-control-registered-overseas-entity",
-              "significant-influence-or-control-as-trust-registered-overseas-entity",
-              "significant-influence-or-control-as-firm-registered-overseas-entity",
-              "part-right-to-share-surplus-assets-25-to-50-percent",
-              "part-right-to-share-surplus-assets-50-to-75-percent",
-              "part-right-to-share-surplus-assets-75-to-100-percent",
-              "part-right-to-share-surplus-assets-25-to-50-percent-as-trust",
-              "part-right-to-share-surplus-assets-50-to-75-percent-as-trust",
-              "part-right-to-share-surplus-assets-75-to-100-percent-as-trust",
-              "part-right-to-share-surplus-assets-25-to-50-percent-as-firm",
-              "part-right-to-share-surplus-assets-50-to-75-percent-as-firm",
-              "part-right-to-share-surplus-assets-75-to-100-percent-as-firm",
-              "right-to-appoint-and-remove-person",
-              "right-to-appoint-and-remove-person-as-firm",
-              "right-to-appoint-and-remove-person-as-trust",
-              "right-to-appoint-and-remove-directors-registered-overseas-entity",
-              "right-to-appoint-and-remove-directors-as-trust-registered-overseas-entity",
-              "right-to-appoint-and-remove-directors-as-firm-registered-overseas-entity"
-            ]
-          },
-          "type": "array"
-        },
-        "notified_on": {
-          "format": "date",
-          "type": "string"
         },
         "reference_etag": {
           "type": "string"
@@ -1107,301 +672,16 @@
         },
         "register_entry_date": {
           "format": "date",
-          "type": "string"
-        },
-        "residential_address": {
-          "$ref": "#/definitions/Address"
-        },
-        "residential_address_same_as_correspondence_address": {
-          "type": "boolean"
-        },
-        "statementActionDate": {
-          "format": "date",
-          "type": "string"
-        },
-        "statementType": {
           "type": "string"
         },
         "updated_at": {
-          "format": "date-time",
           "readOnly": true,
+          "format": "date-time",
           "type": "string"
         }
       },
       "type": "object",
-      "title": "PscIndividualFiling"
-    },
-    "PscWithIdentification": {
-      "properties": {
-        "address": {
-          "$ref": "#/definitions/Address"
-        },
-        "address_same_as_registered_office_address": {
-          "type": "boolean"
-        },
-        "ceased_on": {
-          "format": "date",
-          "type": "string"
-        },
-        "identification": {
-          "$ref": "#/definitions/Identification"
-        },
-        "kind": {
-          "type": "string"
-        },
-        "links": {
-          "$ref": "#/definitions/Links"
-        },
-        "name": {
-          "type": "string"
-        },
-        "naturesOfControl": {
-          "items": {
-            "type": "string",
-            "enum": [
-              "ownership-of-shares-25-to-50-percent",
-              "ownership-of-shares-50-to-75-percent",
-              "ownership-of-shares-75-to-100-percent",
-              "ownership-of-shares-25-to-50-percent-as-trust",
-              "ownership-of-shares-50-to-75-percent-as-trust",
-              "ownership-of-shares-75-to-100-percent-as-trust",
-              "ownership-of-shares-25-to-50-percent-as-firm",
-              "ownership-of-shares-50-to-75-percent-as-firm",
-              "ownership-of-shares-75-to-100-percent-as-firm",
-              "ownership-of-shares-more-than-25-percent-registered-overseas-entity",
-              "ownership-of-shares-more-than-25-percent-as-trust-registered-overseas-entity",
-              "ownership-of-shares-more-than-25-percent-as-firm-registered-overseas-entity",
-              "voting-rights-25-to-50-percent",
-              "voting-rights-50-to-75-percent",
-              "voting-rights-75-to-100-percent",
-              "voting-rights-25-to-50-percent-as-trust",
-              "voting-rights-50-to-75-percent-as-trust",
-              "voting-rights-75-to-100-percent-as-trust",
-              "voting-rights-25-to-50-percent-as-firm",
-              "voting-rights-50-to-75-percent-as-firm",
-              "voting-rights-75-to-100-percent-as-firm",
-              "voting-rights-more-than-25-percent-registered-overseas-entity",
-              "voting-rights-more-than-25-percent-as-trust-registered-overseas-entity",
-              "voting-rights-more-than-25-percent-as-firm-registered-overseas-entity",
-              "right-to-appoint-and-remove-directors",
-              "right-to-appoint-and-remove-directors-as-trust",
-              "right-to-appoint-and-remove-directors-as-firm",
-              "significant-influence-or-control",
-              "significant-influence-or-control-as-trust",
-              "significant-influence-or-control-as-firm",
-              "right-to-share-surplus-assets-25-to-50-percent-limited-liability-partnership",
-              "right-to-share-surplus-assets-50-to-75-percent-limited-liability-partnership",
-              "right-to-share-surplus-assets-75-to-100-percent-limited-liability-partnership",
-              "right-to-share-surplus-assets-25-to-50-percent-as-trust-limited-liability-partnership",
-              "right-to-share-surplus-assets-50-to-75-percent-as-trust-limited-liability-partnership",
-              "right-to-share-surplus-assets-75-to-100-percent-as-trust-limited-liability-partnership",
-              "right-to-share-surplus-assets-25-to-50-percent-as-firm-limited-liability-partnership",
-              "right-to-share-surplus-assets-50-to-75-percent-as-firm-limited-liability-partnership",
-              "right-to-share-surplus-assets-75-to-100-percent-as-firm-limited-liability-partnership",
-              "voting-rights-25-to-50-percent-limited-liability-partnership",
-              "voting-rights-50-to-75-percent-limited-liability-partnership",
-              "voting-rights-75-to-100-percent-limited-liability-partnership",
-              "voting-rights-25-to-50-percent-as-trust-limited-liability-partnership",
-              "voting-rights-50-to-75-percent-as-trust-limited-liability-partnership",
-              "voting-rights-75-to-100-percent-as-trust-limited-liability-partnership",
-              "voting-rights-25-to-50-percent-as-firm-limited-liability-partnership",
-              "voting-rights-50-to-75-percent-as-firm-limited-liability-partnership",
-              "voting-rights-75-to-100-percent-as-firm-limited-liability-partnership",
-              "right-to-appoint-and-remove-members-limited-liability-partnership",
-              "right-to-appoint-and-remove-members-as-trust-limited-liability-partnership",
-              "right-to-appoint-and-remove-members-as-firm-limited-liability-partnership",
-              "significant-influence-or-control-limited-liability-partnership",
-              "significant-influence-or-control-as-trust-limited-liability-partnership",
-              "significant-influence-or-control-as-firm-limited-liability-partnership",
-              "significant-influence-or-control-registered-overseas-entity",
-              "significant-influence-or-control-as-trust-registered-overseas-entity",
-              "significant-influence-or-control-as-firm-registered-overseas-entity",
-              "part-right-to-share-surplus-assets-25-to-50-percent",
-              "part-right-to-share-surplus-assets-50-to-75-percent",
-              "part-right-to-share-surplus-assets-75-to-100-percent",
-              "part-right-to-share-surplus-assets-25-to-50-percent-as-trust",
-              "part-right-to-share-surplus-assets-50-to-75-percent-as-trust",
-              "part-right-to-share-surplus-assets-75-to-100-percent-as-trust",
-              "part-right-to-share-surplus-assets-25-to-50-percent-as-firm",
-              "part-right-to-share-surplus-assets-50-to-75-percent-as-firm",
-              "part-right-to-share-surplus-assets-75-to-100-percent-as-firm",
-              "right-to-appoint-and-remove-person",
-              "right-to-appoint-and-remove-person-as-firm",
-              "right-to-appoint-and-remove-person-as-trust",
-              "right-to-appoint-and-remove-directors-registered-overseas-entity",
-              "right-to-appoint-and-remove-directors-as-trust-registered-overseas-entity",
-              "right-to-appoint-and-remove-directors-as-firm-registered-overseas-entity"
-            ]
-          },
-          "type": "array"
-        },
-        "reference_etag": {
-          "type": "string"
-        },
-        "reference_psc_id": {
-          "type": "string"
-        },
-        "register_entry_date": {
-          "format": "date",
-          "type": "string"
-        },
-        "statementActionDate": {
-          "format": "date",
-          "type": "string"
-        },
-        "statementType": {
-          "type": "string"
-        }
-      },
-      "type": "object",
-      "title": "PSCWithIdentification"
-    },
-    "PscWithIdentificationFiling": {
-      "properties": {
-        "address": {
-          "$ref": "#/definitions/Address"
-        },
-        "address_same_as_registered_office_address": {
-          "type": "boolean"
-        },
-        "ceased_on": {
-          "format": "date",
-          "type": "string"
-        },
-        "created_at": {
-          "format": "date-time",
-          "readOnly": true,
-          "type": "string"
-        },
-        "etag": {
-          "readOnly": true,
-          "type": "string"
-        },
-        "id": {
-          "readOnly": true,
-          "type": "string"
-        },
-        "identification": {
-          "$ref": "#/definitions/Identification"
-        },
-        "kind": {
-          "type": "string"
-        },
-        "links": {
-          "$ref": "#/definitions/Links"
-        },
-        "name": {
-          "type": "string"
-        },
-        "naturesOfControl": {
-          "items": {
-            "type": "string",
-            "enum": [
-              "ownership-of-shares-25-to-50-percent",
-              "ownership-of-shares-50-to-75-percent",
-              "ownership-of-shares-75-to-100-percent",
-              "ownership-of-shares-25-to-50-percent-as-trust",
-              "ownership-of-shares-50-to-75-percent-as-trust",
-              "ownership-of-shares-75-to-100-percent-as-trust",
-              "ownership-of-shares-25-to-50-percent-as-firm",
-              "ownership-of-shares-50-to-75-percent-as-firm",
-              "ownership-of-shares-75-to-100-percent-as-firm",
-              "ownership-of-shares-more-than-25-percent-registered-overseas-entity",
-              "ownership-of-shares-more-than-25-percent-as-trust-registered-overseas-entity",
-              "ownership-of-shares-more-than-25-percent-as-firm-registered-overseas-entity",
-              "voting-rights-25-to-50-percent",
-              "voting-rights-50-to-75-percent",
-              "voting-rights-75-to-100-percent",
-              "voting-rights-25-to-50-percent-as-trust",
-              "voting-rights-50-to-75-percent-as-trust",
-              "voting-rights-75-to-100-percent-as-trust",
-              "voting-rights-25-to-50-percent-as-firm",
-              "voting-rights-50-to-75-percent-as-firm",
-              "voting-rights-75-to-100-percent-as-firm",
-              "voting-rights-more-than-25-percent-registered-overseas-entity",
-              "voting-rights-more-than-25-percent-as-trust-registered-overseas-entity",
-              "voting-rights-more-than-25-percent-as-firm-registered-overseas-entity",
-              "right-to-appoint-and-remove-directors",
-              "right-to-appoint-and-remove-directors-as-trust",
-              "right-to-appoint-and-remove-directors-as-firm",
-              "significant-influence-or-control",
-              "significant-influence-or-control-as-trust",
-              "significant-influence-or-control-as-firm",
-              "right-to-share-surplus-assets-25-to-50-percent-limited-liability-partnership",
-              "right-to-share-surplus-assets-50-to-75-percent-limited-liability-partnership",
-              "right-to-share-surplus-assets-75-to-100-percent-limited-liability-partnership",
-              "right-to-share-surplus-assets-25-to-50-percent-as-trust-limited-liability-partnership",
-              "right-to-share-surplus-assets-50-to-75-percent-as-trust-limited-liability-partnership",
-              "right-to-share-surplus-assets-75-to-100-percent-as-trust-limited-liability-partnership",
-              "right-to-share-surplus-assets-25-to-50-percent-as-firm-limited-liability-partnership",
-              "right-to-share-surplus-assets-50-to-75-percent-as-firm-limited-liability-partnership",
-              "right-to-share-surplus-assets-75-to-100-percent-as-firm-limited-liability-partnership",
-              "voting-rights-25-to-50-percent-limited-liability-partnership",
-              "voting-rights-50-to-75-percent-limited-liability-partnership",
-              "voting-rights-75-to-100-percent-limited-liability-partnership",
-              "voting-rights-25-to-50-percent-as-trust-limited-liability-partnership",
-              "voting-rights-50-to-75-percent-as-trust-limited-liability-partnership",
-              "voting-rights-75-to-100-percent-as-trust-limited-liability-partnership",
-              "voting-rights-25-to-50-percent-as-firm-limited-liability-partnership",
-              "voting-rights-50-to-75-percent-as-firm-limited-liability-partnership",
-              "voting-rights-75-to-100-percent-as-firm-limited-liability-partnership",
-              "right-to-appoint-and-remove-members-limited-liability-partnership",
-              "right-to-appoint-and-remove-members-as-trust-limited-liability-partnership",
-              "right-to-appoint-and-remove-members-as-firm-limited-liability-partnership",
-              "significant-influence-or-control-limited-liability-partnership",
-              "significant-influence-or-control-as-trust-limited-liability-partnership",
-              "significant-influence-or-control-as-firm-limited-liability-partnership",
-              "significant-influence-or-control-registered-overseas-entity",
-              "significant-influence-or-control-as-trust-registered-overseas-entity",
-              "significant-influence-or-control-as-firm-registered-overseas-entity",
-              "part-right-to-share-surplus-assets-25-to-50-percent",
-              "part-right-to-share-surplus-assets-50-to-75-percent",
-              "part-right-to-share-surplus-assets-75-to-100-percent",
-              "part-right-to-share-surplus-assets-25-to-50-percent-as-trust",
-              "part-right-to-share-surplus-assets-50-to-75-percent-as-trust",
-              "part-right-to-share-surplus-assets-75-to-100-percent-as-trust",
-              "part-right-to-share-surplus-assets-25-to-50-percent-as-firm",
-              "part-right-to-share-surplus-assets-50-to-75-percent-as-firm",
-              "part-right-to-share-surplus-assets-75-to-100-percent-as-firm",
-              "right-to-appoint-and-remove-person",
-              "right-to-appoint-and-remove-person-as-firm",
-              "right-to-appoint-and-remove-person-as-trust",
-              "right-to-appoint-and-remove-directors-registered-overseas-entity",
-              "right-to-appoint-and-remove-directors-as-trust-registered-overseas-entity",
-              "right-to-appoint-and-remove-directors-as-firm-registered-overseas-entity"
-            ]
-          },
-          "type": "array"
-        },
-        "notified_on": {
-          "format": "date",
-          "type": "string"
-        },
-        "reference_etag": {
-          "type": "string"
-        },
-        "reference_psc_id": {
-          "type": "string"
-        },
-        "register_entry_date": {
-          "format": "date",
-          "type": "string"
-        },
-        "statementActionDate": {
-          "format": "date",
-          "type": "string"
-        },
-        "statementType": {
-          "type": "string"
-        },
-        "updated_at": {
-          "format": "date-time",
-          "readOnly": true,
-          "type": "string"
-        }
-      },
-      "type": "object",
-      "title": "PscWithIdentificationFiling"
+      "title": "PscFilingResource"
     },
     "ValidationStatusError": {
       "properties": {

--- a/docs/spec-v2.0.json
+++ b/docs/spec-v2.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "PSC Filing API (Private)",
     "version": "0.3",
-    "description": "Private specification for the PSC Filings service (currently for PSC07 [Cease a PSC] only).\nIncludes:\n * Public paths for use by third party software filers and CHS, and\n* Private paths for CHS internal users only.\n* Data models for any of PSC01 to PSC09\n---\n ### NOTE\n**Only PSC07 is currently supported**. It requires only the following properties:\n* `ceased_on`\n* `register_entry-date`\n* `reference_psc_id`\n* `reference_etag`"
+    "description": "Private specification for the PSC Filings service (currently for PSC07 [Cease a PSC] only).\nIncludes:\n * Public paths for use by third party software filers and CHS, and\n* Private paths for CHS internal users only, and\n* Data models for any of PSC01 to PSC09.\n\n---\n### NOTE\n**Only PSC07 is currently supported**. It requires only the following properties:\n* `ceased_on`\n* `register_entry-date`\n* `reference_psc_id`\n* `reference_etag`"
   },
   "host": "api.chs.local:4001",
   "basePath": "/",
@@ -17,24 +17,8 @@
   ],
   "tags": [
     {
-      "name": "PSC Filing",
-      "description": "For creating, updating, and retrieving PSC filings"
-    },
-    {
-      "name": "Filing Data",
-      "description": "For use by the CHS filing resource handler service."
-    },
-    {
-      "name": "Validation Status",
-      "description": "For public use and for the CHS transaction service when attempting to close a transaction."
-    },
-    {
-      "name": "Public Access",
-      "description": "For public use"
-    },
-    {
-      "name": "Private Access",
-      "description": "For internal use only"
+      "name": "pscFiling",
+      "description": "PSC filing"
     }
   ],
   "paths": {
@@ -81,10 +65,10 @@
           }
         },
         "tags": [
-          "Filing Data",
-          "Private Access"
+          "pscFiling"
         ],
-        "operationId": "getFilingsData"
+        "operationId": "getFilingsData",
+        "x-operationName": "provide filings data"
       }
     },
     "/transactions/{transactionId}/persons-with-significant-control/{filingResourceId}/validation_status": {
@@ -119,15 +103,15 @@
           }
         },
         "tags": [
-          "Validation Status",
-          "Public Access"
+          "pscFiling"
         ],
-        "operationId": "validateFiling"
+        "operationId": "validateFiling",
+        "x-operationName": "validate filing"
       }
     },
     "/transactions/{transactionId}/persons-with-significant-control/individual": {
       "post": {
-        "description": "Create a filing for an Individual PSC.",
+        "summary": "Create a filing for an Individual PSC.",
         "consumes": [
           "application/json"
         ],
@@ -171,10 +155,10 @@
           }
         },
         "tags": [
-          "PSC Filing",
-          "Public Access"
+          "pscFiling"
         ],
-        "operationId": "createIndividualPscFiling"
+        "operationId": "createIndividualPscFiling",
+        "x-operationName": "create individual filing"
       }
     },
     "/transactions/{transactionId}/persons-with-significant-control/corporate-entity": {
@@ -223,10 +207,10 @@
           }
         },
         "tags": [
-          "PSC Filing",
-          "Public Access"
+          "pscFiling"
         ],
-        "operationId": "createCorporateEntityPscFiling"
+        "operationId": "createCorporateEntityPscFiling",
+        "x-operationName": "create corporate entity filing"
       }
     },
     "/transactions/{transactionId}/persons-with-significant-control/legal-person": {
@@ -275,10 +259,10 @@
           }
         },
         "tags": [
-          "PSC Filing",
-          "Public Access"
+          "pscFiling"
         ],
-        "operationId": "createLegalPersonPscFiling"
+        "operationId": "createLegalPersonPscFiling",
+        "x-operationName": "create legal person filing"
       }
     },
     "/transactions/{transactionId}/persons-with-significant-control/{pscType}/{filingResourceId}": {
@@ -313,10 +297,10 @@
           }
         },
         "tags": [
-          "PSC Filing",
-          "Public Access"
+          "pscFiling"
         ],
-        "operationId": "getFilingForReview"
+        "operationId": "getFilingForReview",
+        "x-operationName": "get filing for review"
       },
       "patch": {
         "description": "Update permitted properties of a PSC filing resource. Supports adding, replacing or removing properties specified in the request body &mdash; see [RFC7396](https://www.rfc-editor.org/rfc/rfc7396) for details.\n### NOTE\n Certain properties of the filing are **read only**. If present in the request body they will be **ignored**, and `updated_at` will be modified automatically.\n* `id`\n* `created_at`\n* `updated_at` (modified automatically)\n* `links`\n",
@@ -364,10 +348,10 @@
           }
         },
         "tags": [
-          "PSC Filing",
-          "Public Access"
+          "pscFiling"
         ],
-        "operationId": "updateFiling"
+        "operationId": "updateFiling",
+        "x-operationName": "update filing"
       }
     }
   },
@@ -410,6 +394,7 @@
           "type": "object"
         },
         "type": "object",
+        "title": "patchBody",
         "example": {
           "register_entry_date": "2023-02-11"
         }
@@ -632,6 +617,7 @@
       "description": "#### Unauthorized\nRequest credentials/authorization are invalid or missing.",
       "schema": {
         "type": "object",
+        "title": "UnauthorizedResponse",
         "properties": {
           "error": {
             "type": "string"
@@ -713,7 +699,8 @@
           "type": "string"
         }
       },
-      "type": "object"
+      "type": "object",
+      "title": "Address"
     },
     "ApiError": {
       "properties": {
@@ -736,12 +723,8 @@
           "type": "string"
         }
       },
-      "type": "object"
-    },
-    "FilingNotFoundError": {
       "type": "object",
-      "properties": {
-      }
+      "title": "ApiError"
     },
     "ApiErrors": {
       "properties": {
@@ -753,7 +736,8 @@
           "uniqueItems": true
         }
       },
-      "type": "object"
+      "type": "object",
+      "title": "ApiErrors"
     },
     "Date": {
       "properties": {
@@ -770,7 +754,8 @@
           "type": "integer"
         }
       },
-      "type": "object"
+      "type": "object",
+      "title": "Date"
     },
     "FilingApi": {
       "properties": {
@@ -796,7 +781,8 @@
           "type": "string"
         }
       },
-      "type": "object"
+      "type": "object",
+      "title": "FilingApi"
     },
     "Identification": {
       "properties": {
@@ -816,7 +802,8 @@
           "type": "string"
         }
       },
-      "type": "object"
+      "type": "object",
+      "title": "Identification"
     },
     "Links": {
       "properties": {
@@ -829,7 +816,8 @@
           "type": "string"
         }
       },
-      "type": "object"
+      "type": "object",
+      "title": "Links"
     },
     "NameElements": {
       "properties": {
@@ -846,7 +834,8 @@
           "type": "string"
         }
       },
-      "type": "object"
+      "type": "object",
+      "title": "NameElements"
     },
     "PscIndividual": {
       "properties": {
@@ -980,7 +969,8 @@
           "type": "string"
         }
       },
-      "type": "object"
+      "type": "object",
+      "title": "PscIndividual"
     },
     "PscIndividualFiling": {
       "properties": {
@@ -1138,7 +1128,8 @@
           "type": "string"
         }
       },
-      "type": "object"
+      "type": "object",
+      "title": "PscIndividualFiling"
     },
     "PscWithIdentification": {
       "properties": {
@@ -1262,7 +1253,8 @@
           "type": "string"
         }
       },
-      "type": "object"
+      "type": "object",
+      "title": "PSCWithIdentification"
     },
     "PscWithIdentificationFiling": {
       "properties": {
@@ -1408,7 +1400,8 @@
           "type": "string"
         }
       },
-      "type": "object"
+      "type": "object",
+      "title": "PscWithIdentificationFiling"
     },
     "ValidationStatusError": {
       "properties": {
@@ -1425,7 +1418,8 @@
           "type": "string"
         }
       },
-      "type": "object"
+      "type": "object",
+      "title": "ValidationStatusError"
     },
     "ValidationStatus": {
       "properties": {
@@ -1439,8 +1433,8 @@
           "type": "boolean"
         }
       },
-      "type": "object"
+      "type": "object",
+      "title": "ValidationStatus"
     }
-  },
-  "x-components": {}
+  }
 }

--- a/docs/spec-v2.0.json
+++ b/docs/spec-v2.0.json
@@ -2,8 +2,8 @@
   "swagger": "2.0",
   "info": {
     "title": "PSC Filing API (Private)",
-    "version": "0.2",
-    "description": "Private specification for the PSC Filings service (currently for PSC07 [Cease a PSC] only). Includes:\n * Public paths for use by third party software filers and \n* Private paths for CHS internal users.\n---\n ### NOTE\nModels include data properties required for any of PSC01 to PSC09, however most are currently unused.\n\nPSC07 requires only\n* `ceased_on`\n* `register_entry-date`\n* `reference_psc_id`\n* `reference_etag`"
+    "version": "0.3",
+    "description": "Private specification for the PSC Filings service (currently for PSC07 [Cease a PSC] only).\nIncludes:\n * Public paths for use by third party software filers and CHS, and\n* Private paths for CHS internal users only.\n* Data models for any of PSC01 to PSC09\n---\n ### NOTE\n**Only PSC07 is currently supported**. It requires only the following properties:\n* `ceased_on`\n* `register_entry-date`\n* `reference_psc_id`\n* `reference_etag`"
   },
   "host": "api.chs.local:4001",
   "basePath": "/",
@@ -40,6 +40,7 @@
   "paths": {
     "/private/transactions/{transactionId}/persons-with-significant-control/{pscType}/{filingResourceId}/filings": {
       "get": {
+        "description": "Provide enhanced filing data needed to submit the PSC filing to CHIPS. For internal use by the filing resource handler service.",
         "produces": [
           "application/json"
         ],
@@ -61,19 +62,13 @@
         ],
         "responses": {
           "200": {
-            "description": "OK",
-            "schema": {
-              "items": {
-                "$ref": "#/definitions/FilingApi"
-              },
-              "type": "array"
-            }
+            "$ref": "#/responses/FilingData"
           },
           "401": {
             "$ref": "#/responses/Unauthorized"
           },
           "403": {
-            "description": "Forbidden \n* The authorization identity type must equal 'key' \n* The authenticated user account must have internal user privileges \n* The request must have an API key that has internal application privileges"
+            "description": "Forbidden \n* The authorization identity type must equal '`key`' and \n* The authenticated user account must have internal user privileges and\n* The request must have an API key that has internal application privileges."
           },
           "404": {
               "$ref": "#/responses/FilingNotFound"
@@ -82,7 +77,7 @@
             "$ref": "#/responses/Conflict"
           },
           "500": {
-            "$ref": "#/responses/InternalServerError"
+            "description": "#### Internal Server Error\nThe request could not be fulfilled due to:\n* The filing resource transaction is not Closed or\n* an internal error."
           }
         },
         "tags": [
@@ -94,6 +89,7 @@
     },
     "/transactions/{transactionId}/persons-with-significant-control/{filingResourceId}/validation_status": {
       "get": {
+        "description": "Check the validity of a PSC filing. When a request is made to the Transaction Service to close the filing resource transaction, that service makes a request to this path. If valid, the Transaction Service closes the transaction and marks it for processing.",
         "produces": [
           "application/json"
         ],
@@ -107,9 +103,9 @@
         ],
         "responses": {
           "200": {
-            "description": "OK",
+            "description": "#### OK\nThe validation operation completed successfully. The `is_valid` property in the response body indicates the validity of the filing. The `errors` property in the response body contains details of any validation errors.\n#### Examples:\n<table><tr><td>\n\n**is_valid**\n\n</td><td>\n\n**errors**\n\n</td></tr><tr><td>true</td><td>\n\n`[]`\n\n</td></tr><tr><td>false</td><td>\n\n```\n[\n\t{\n\t\t\"error\": \"PSC register entry date must be on or after the date the PSC was ceased\",\n\t\t\"location\": \"$.register_entry_date\",\n\t\t\"type\": \"ch:validation\",\n\t\t\"location_type\": \"json-path\"\n\t}\n]\n```\n\n</td></tr></table>",
             "schema": {
-              "$ref": "#/definitions/ValidationStatusResponse"
+              "$ref": "#/definitions/ValidationStatus"
             }
           },
           "401": {
@@ -117,9 +113,6 @@
           },
           "404": {
             "$ref": "#/responses/FilingNotFound"
-          },
-          "409": {
-            "$ref": "#/responses/Conflict"
           },
           "500": {
             "$ref": "#/responses/InternalServerError"
@@ -129,11 +122,12 @@
           "Validation Status",
           "Public Access"
         ],
-        "operationId": "validate"
+        "operationId": "validateFiling"
       }
     },
     "/transactions/{transactionId}/persons-with-significant-control/individual": {
       "post": {
+        "description": "Create a filing for an Individual PSC.",
         "consumes": [
           "application/json"
         ],
@@ -146,7 +140,7 @@
           },
           {
             "in": "body",
-            "name": "body",
+            "name": "filingBody",
             "required": true,
             "schema": {
               "$ref": "#/definitions/PscIndividual"
@@ -167,7 +161,7 @@
             "$ref": "#/responses/Forbidden"
           },
           "404": {
-            "$ref": "#/responses/NotFound"
+            "$ref": "#/responses/NotCreated"
           },
           "409": {
             "$ref": "#/responses/Conflict"
@@ -185,6 +179,7 @@
     },
     "/transactions/{transactionId}/persons-with-significant-control/corporate-entity": {
       "post": {
+        "description": "Create a filing for an Corporate Entity PSC.",
         "consumes": [
           "application/json"
         ],
@@ -197,7 +192,7 @@
           },
           {
             "in": "body",
-            "name": "body",
+            "name": "filingBody",
             "required": true,
             "schema": {
               "$ref": "#/definitions/PscWithIdentification"
@@ -218,7 +213,7 @@
             "$ref": "#/responses/Forbidden"
           },
           "404": {
-            "$ref": "#/responses/NotFound"
+            "$ref": "#/responses/NotCreated"
           },
           "409": {
             "$ref": "#/responses/Conflict"
@@ -236,6 +231,7 @@
     },
     "/transactions/{transactionId}/persons-with-significant-control/legal-person": {
       "post": {
+        "description": "Create a filing for an Legal Person PSC.",
         "consumes": [
           "application/json"
         ],
@@ -248,7 +244,7 @@
           },
           {
             "in": "body",
-            "name": "body",
+            "name": "filingBody",
             "required": true,
             "schema": {
               "$ref": "#/definitions/PscWithIdentification"
@@ -269,7 +265,7 @@
             "$ref": "#/responses/Forbidden"
           },
           "404": {
-            "$ref": "#/responses/NotFound"
+            "$ref": "#/responses/NotCreated"
           },
           "409": {
             "$ref": "#/responses/Conflict"
@@ -287,6 +283,7 @@
     },
     "/transactions/{transactionId}/persons-with-significant-control/{pscType}/{filingResourceId}": {
       "get": {
+        "description": "Fetch a PSC filing resource.",
         "produces": [
           "application/json"
         ],
@@ -309,10 +306,7 @@
             "$ref": "#/responses/Unauthorized"
           },
           "404": {
-            "$ref": "#/responses/FilingNotFound"
-          },
-          "409": {
-            "$ref": "#/responses/Conflict"
+            "$ref": "#/responses/NotFound"
           },
           "500": {
             "$ref": "#/responses/InternalServerError"
@@ -325,6 +319,7 @@
         "operationId": "getFilingForReview"
       },
       "patch": {
+        "description": "Update permitted properties of a PSC filing resource. Supports adding, replacing or removing properties specified in the request body &mdash; see [RFC7396](https://www.rfc-editor.org/rfc/rfc7396) for details.\n### NOTE\n Certain properties of the filing are **read only**. If present in the request body they will be **ignored**, and `updated_at` will be modified automatically.\n* `id`\n* `created_at`\n* `updated_at` (modified automatically)\n* `links`\n",
         "consumes": [
           "application/merge-patch+json"
         ],
@@ -342,25 +337,15 @@
             "$ref": "#/parameters/filingResourceId"
           },
           {
-            "in": "body",
-            "name": "body",
-            "required": true,
-            "schema": {
-              "additionalProperties": {
-                "type": "object"
-              },
-              "type": "object"
-            }
+            "$ref": "#/parameters/patchBody"
           }
         ],
         "responses": {
           "200": {
-            "description": "OK",
-            "schema": {}
+            "$ref": "#/responses/PscFilingUpdated"
           },
           "400": {
-            "description": "Bad Request",
-            "schema": {}
+            "$ref": "#/responses/UpdateFilingBadRequest"
           },
           "401": {
             "$ref": "#/responses/Unauthorized"
@@ -415,6 +400,20 @@
       "type": "string",
       "description": "The unique ID of the filing resource",
       "x-example": "63a0776f339d254f9fc04a35"
+    },
+    "patchBody": {
+      "in": "body",
+      "name": "patchBody",
+      "required": true,
+      "schema": {
+        "additionalProperties": {
+          "type": "object"
+        },
+        "type": "object",
+        "example": {
+          "register_entry_date": "2023-02-11"
+        }
+      }
     }
   },
   "responses": {
@@ -496,6 +495,29 @@
         }
       }
     },
+    "FilingData": {
+      "description": "#### OK\n",
+      "schema": {
+        "items": {
+          "$ref": "#/definitions/FilingApi"
+        },
+        "type": "array",
+        "example": [
+          {
+            "data": {
+              "title": "Mr",
+              "first_name": "Random",
+              "other_forenames": "Notreal",
+              "last_name": "Person",
+              "ceased_on": "2022-08-30",
+              "register_entry_date": "2022-10-15"
+            },
+            "description": "(PSC07) Notice of ceasing to be a Person of Significant Control for Mr Random Notreal Person on 30 August 2022",
+            "kind": "psc-filing#cessation#individual"
+          }
+        ]
+      }
+    },
     "Forbidden": {
       "description": "#### Forbidden\nThe filing resource transaction is not in an open state, or the operation is otherwise not allowed."
     },
@@ -517,29 +539,11 @@
         }
       }
     },
-    "NotFound": {
+    "NotCreated": {
       "description": "Not Found\nThe filing resource could not be created due to any of: \n* The transaction ID in the request path does not match an existing transaction or\n* The PSC type in the last segment of the path does not match one of the accepted values:\n\t* `individual`\n\t* `corporate-entity`\n\t* `legal-person`"
     },
-    "PscIndividualFilingCreated": {
-      "description": "#### Created\nFor convenience the response body provides the representation of the created filing resource.",
-      "schema": {
-        "$ref": "#/definitions/PscIndividualFiling"
-      },
-      "examples": {
-        "application/json": {
-          "ceased_on": "2022-08-29",
-          "links": {
-            "self": "/transactions/021576-444716-850996/persons-with-significant-control/individual/6470946f9f4c3f6c1ed25a19",
-            "validation_status": "/transactions/021576-444716-850996/persons-with-significant-control/6470946f9f4c3f6c1ed25a19/validation_status"
-          },
-          "reference_etag": "8cb9d4c9ba82059ff01ed638105bc41c1bc4db40",
-          "reference_psc_id": "1kdaTltWeaP1EB70SSD9SLmiK5Y",
-          "register_entry_date": "2022-10-15",
-          "id": "6470946f9f4c3f6c1ed25a19",
-          "created_at": "2023-05-26T11:13:51.787Z",
-          "updated_at": "2023-05-26T11:13:51.787Z"
-        }
-      }
+    "NotFound": {
+      "description": "Not Found\nA filing having the specified combination of transaction ID, filing resource ID and PSC type could not be found."
     },
     "PscCorporateEntityFilingCreated": {
       "description": "#### Created\nFor convenience the response body provides the representation of the created filing resource.",
@@ -559,6 +563,27 @@
           "id": "64410d94aa51447dcf469570",
           "created_at": "2023-04-20T10:01:56.129Z",
           "updated_at": "2023-04-20T10:01:56.129Z"
+        }
+      }
+    },
+    "PscIndividualFilingCreated": {
+      "description": "#### Created\nFor convenience the response body provides the representation of the created filing resource.",
+      "schema": {
+        "$ref": "#/definitions/PscIndividualFiling"
+      },
+      "examples": {
+        "application/json": {
+          "ceased_on": "2022-08-29",
+          "links": {
+            "self": "/transactions/021576-444716-850996/persons-with-significant-control/individual/6470946f9f4c3f6c1ed25a19",
+            "validation_status": "/transactions/021576-444716-850996/persons-with-significant-control/6470946f9f4c3f6c1ed25a19/validation_status"
+          },
+          "reference_etag": "8cb9d4c9ba82059ff01ed638105bc41c1bc4db40",
+          "reference_psc_id": "1kdaTltWeaP1EB70SSD9SLmiK5Y",
+          "register_entry_date": "2022-10-15",
+          "id": "6470946f9f4c3f6c1ed25a19",
+          "created_at": "2023-05-26T11:13:51.787Z",
+          "updated_at": "2023-05-26T11:13:51.787Z"
         }
       }
     },
@@ -582,8 +607,29 @@
         }
       }
     },
+    "PscFilingUpdated": {
+      "description": "#### OK\nFor convenience the response body provides the representation of the updated filing resource.",
+      "schema": {
+        "$ref": "#/definitions/PscWithIdentificationFiling"
+      },
+      "examples": {
+        "application/json": {
+          "ceased_on": "2023-04-19",
+          "links": {
+            "self": "/transactions/098781-975316-819849/persons-with-significant-control/corporate-entity/64410d94aa51447dcf469570",
+            "validation_status": "/transactions/098781-975316-819849/persons-with-significant-control/64410d94aa51447dcf469570/validation_status"
+          },
+          "reference_etag": "4e5fda8b2b6dba10862965ee34d80915d7b48266",
+          "reference_psc_id": "fhhMkjhxbWGc0juOZvDhNcbFn8o",
+          "register_entry_date": "2023-02-11",
+          "id": "64410d94aa51447dcf469570",
+          "created_at": "2023-04-20T10:01:56.129Z",
+          "updated_at": "2023-04-25T12:44:02.290Z"
+        }
+      }
+    },
     "Unauthorized": {
-      "description": "#### Unauthorized.\nCredentials/authorization are invalid or missing.",
+      "description": "#### Unauthorized\nRequest credentials/authorization are invalid or missing.",
       "schema": {
         "type": "object",
         "properties": {
@@ -597,6 +643,24 @@
         "example": {
           "error": "Invalid Authorization",
           "type": "ch:service"
+        }
+      }
+    },
+    "UpdateFilingBadRequest": {
+      "description": "#### Bad Request\nThe request to update a filing resource contains bad data.",
+      "examples": {
+        "application/json": {
+          "errors": [
+            {
+              "error": "{rejected-value} must be a date in the past or in the present",
+              "error_values": {
+                "rejected-value": "3000-08-30"
+              },
+              "location": "$.ceased_on",
+              "location_type": "json-path",
+              "type": "ch:validation"
+            }
+          ]
         }
       }
     }
@@ -1363,7 +1427,7 @@
       },
       "type": "object"
     },
-    "ValidationStatusResponse": {
+    "ValidationStatus": {
       "properties": {
         "errors": {
           "items": {

--- a/run_dapperdox.sh
+++ b/run_dapperdox.sh
@@ -1,6 +1,6 @@
 ${DAPPERDOX}/dapperdox \
     -spec-dir=${PWD}/docs/ \
-    -spec-filename=spec-v2.0.json \
+    -spec-filename=psc-filing-api.json \
     -bind-addr=0.0.0.0:4005 \
     -site-url=http://localhost:4005 \
     -log-level=debug \

--- a/run_dapperdox.sh
+++ b/run_dapperdox.sh
@@ -1,0 +1,20 @@
+${DAPPERDOX}/dapperdox \
+    -spec-dir=${PWD}/docs/ \
+    -spec-filename=spec-v2.0.json \
+    -bind-addr=0.0.0.0:4005 \
+    -site-url=http://localhost:4005 \
+    -log-level=debug \
+    -spec-rewrite-url=http://localhost:3123/swagger-2.0 \
+    -spec-rewrite-url=localhost:4003=http://localhost:4005 \
+    -document-rewrite-url=http://localhost:4003=http://localhost:4005 \
+    -default-assets-dir=${DAPPERDOX}/assets \
+    -proxy-path=/developer=http://localhost:4006 \
+    -force-specification-list=true \
+    -author-show-assets=true \
+    -assets-dir=${PWD}/assets \
+    -theme-dir=$HOME/src/SingleService/dapperdox-themes/ \
+    -theme=dapperdox-theme-gov-uk  \
+    #-tls-certificate=server.rsa.crt \
+    #-tls-key=server.rsa.key \
+    #-assets-dir=./examples/overlay/assets \
+   # -spec-dir=examples/specifications/petstore/ \


### PR DESCRIPTION
Instructions on how to download and configure DapperDox can be found [here](http://dapperdox.io/docs/getting-started).

Once dapperdox is installed

1. set env var `DAPPERDOX` to the install directory (preferably in your shell's login script), e.g. 

  ```bash
  export DAPPERDOX=~/dev/dapperdox
  ```
2. run dapperdox with

  ```bash
  ./run_dapperdox.sh
  ```
3.  navigate your browser to
```
http://localhost:4005
```

