### PR TITLE
Fix stacktrace response when dependent CHS service unavailable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <!--- CH -->
         <structured-logging.version>1.9.14</structured-logging.version>
         <private-api-sdk-java.version>2.0.187</private-api-sdk-java.version>
-        <api-sdk-java.version>4.3.23</api-sdk-java.version>
+        <api-sdk-java.version>4.3.30</api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <api-security-java.version>0.4.0</api-security-java.version>
         <!--sonar configuration-->

--- a/src/main/java/uk/gov/companieshouse/pscfiling/api/error/RestExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/pscfiling/api/error/RestExceptionHandler.java
@@ -197,7 +197,7 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
 
         if (ex instanceof IllegalArgumentException
             && ex.getCause() != null
-            && ex.getCause().getMessage().matches(".*expected numeric type.*")) {
+            && ex.getCause().getMessage().contains("expected numeric type")) {
             logError(chLogger, request, "A dependent CHS service may be unavailable", ex);
         }
         error.addErrorValue("error",

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/impl/RestExceptionHandlerIT.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/controller/impl/RestExceptionHandlerIT.java
@@ -1,0 +1,98 @@
+package uk.gov.companieshouse.pscfiling.api.controller.impl;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Clock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.companieshouse.api.model.psc.PscApi;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.pscfiling.api.config.enumerations.PscFilingConfig;
+import uk.gov.companieshouse.pscfiling.api.mapper.PscMapper;
+import uk.gov.companieshouse.pscfiling.api.service.FilingValidationService;
+import uk.gov.companieshouse.pscfiling.api.service.PscDetailsService;
+import uk.gov.companieshouse.pscfiling.api.service.PscFilingService;
+import uk.gov.companieshouse.pscfiling.api.service.PscIndividualFilingService;
+import uk.gov.companieshouse.pscfiling.api.service.TransactionService;
+
+@Tag("web")
+@WebMvcTest(controllers = PscIndividualFilingControllerImpl.class)
+@Import(PscFilingConfig.class)
+class RestExceptionHandlerIT extends BaseControllerIT {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TransactionService transactionService;
+    @MockBean
+    private PscDetailsService pscDetailsService;
+    @MockBean
+    private FilingValidationService filingValidationService;
+    @MockBean
+    private PscApi pscDetails;
+    @MockBean
+    private PscFilingService pscFilingService;
+    @MockBean
+    private PscIndividualFilingService pscIndividualFilingService;
+    @MockBean
+    private PscMapper filingMapper;
+    @MockBean
+    private Clock clock;
+    @MockBean
+    private Logger logger;
+
+
+    @BeforeEach
+    void setUp() throws Exception {
+        baseSetUp();
+    }
+
+    @Override
+    protected void setupEricTokenPermissions() {
+        // don't add any ERIC permissions
+    }
+
+    @Test
+    @DisplayName("handles transaction service unavailable error gracefully")
+    void handleTransactionServiceUnavailable() throws Exception {
+        final var body = "{" + PSC07_FRAGMENT + "}";
+
+        // simulate exception caused by transaction-api service unavailable
+        // caused by JSON parse error in api-sdk-java
+        final var cause = new IllegalArgumentException(
+            "expected numeric type but got class uk.gov.companieshouse.api.error.ApiErrorResponse");
+
+        when(transactionInterceptor.preHandle(any(), any(), any())).thenThrow(
+            new IllegalArgumentException("", cause)); // message intentionally blank
+
+        mockMvc.perform(post(URL_PSC_INDIVIDUAL, TRANS_ID).content(body)
+                .contentType(APPLICATION_JSON)
+                .headers(httpHeaders))
+            .andDo(print())
+            .andExpect(status().isInternalServerError())
+            .andExpect(header().doesNotExist("location"))
+            .andExpect(jsonPath("$.errors", hasSize(1)))
+            .andExpect(jsonPath("$.errors[0].error", is("Service Unavailable: {error}")))
+            .andExpect(
+                jsonPath("$.errors[0].error_values", hasEntry("error", "Internal server error")))
+            .andExpect(jsonPath("$.errors[0].type", is("ch:service")))
+            .andExpect(jsonPath("$.errors[0].location_type", is("resource")));
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/error/RestExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/error/RestExceptionHandlerTest.java
@@ -410,7 +410,8 @@ class RestExceptionHandlerTest {
             new ApiError("Service Unavailable: {error}", "/path/to/resource", "resource",
                 "ch:service");
 
-        expectedError.addErrorValue("error", exception.getMessage());
+        expectedError.addErrorValue("error",
+            StringUtils.defaultIfBlank(exception.getMessage(), "Internal server error"));
 
         assertThat(apiErrors.getErrors(), contains(expectedError));
     }
@@ -494,7 +495,9 @@ class RestExceptionHandlerTest {
             Arguments.of(
                 new TransactionServiceException("Transaction details unavailable", causeCause)),
             Arguments.of(
-                new CompanyProfileServiceException("Company profile details unavailable", null)));
+                new CompanyProfileServiceException("Company profile details unavailable", null)),
+            Arguments.of(new NullPointerException(null)),
+            Arguments.of(new IllegalArgumentException("", new NullPointerException(null))));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/pscfiling/api/error/RestExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscfiling/api/error/RestExceptionHandlerTest.java
@@ -21,8 +21,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Stream;
+import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -407,10 +407,10 @@ class RestExceptionHandlerTest {
 
         final var apiErrors = testExceptionHandler.handleServiceException(exception, request);
         final var expectedError =
-                new ApiError(exception.getMessage(), "/path/to/resource", "resource", "ch:service");
+            new ApiError("Service Unavailable: {error}", "/path/to/resource", "resource",
+                "ch:service");
 
-        Optional.ofNullable(exception.getCause())
-                .ifPresent(e -> expectedError.addErrorValue("cause", e.getMessage()));
+        expectedError.addErrorValue("error", exception.getMessage());
 
         assertThat(apiErrors.getErrors(), contains(expectedError));
     }
@@ -424,21 +424,53 @@ class RestExceptionHandlerTest {
         when(request.resolveReference("request")).thenReturn(servletRequest);
 
         final var response =
-                testExceptionHandler.handleExceptionInternal(exception, body, new HttpHeaders(),
-                        HttpStatus.INTERNAL_SERVER_ERROR, request);
+            testExceptionHandler.handleExceptionInternal(exception, body, new HttpHeaders(),
+                HttpStatus.INTERNAL_SERVER_ERROR, request);
 
         final var apiErrors = (ApiErrors) response.getBody();
         final var expectedError =
-                new ApiError("test", "/path/to/resource", "resource", "ch:service");
+            new ApiError("Service Unavailable: {error}", "/path/to/resource", "resource",
+                "ch:service");
+        expectedError.addErrorValue("error", "test");
 
         assertThat(apiErrors, is(notNullValue()));
         assertThat(apiErrors.getErrors(), contains(expectedError));
     }
 
+    @ParameterizedTest(name = "[{index}]: exception={0}")
+    @MethodSource("exceptionProvider")
+    void handleAllUncaughtException(final RuntimeException exception) {
+        when(request.getRequest()).thenReturn(servletRequest);
+        when(request.resolveReference("request")).thenReturn(servletRequest);
+
+        final var apiErrors = testExceptionHandler.handleAllUncaughtException(exception, request);
+
+        final var expectedError =
+            new ApiError("Service Unavailable: {error}", "/path/to/resource", "resource",
+                "ch:service");
+
+        expectedError.addErrorValue("error", StringUtils.defaultIfBlank(exception.getMessage(),
+            "Internal server error"));
+        assertThat(apiErrors.getErrors(), contains(expectedError));
+    }
+
+    private static Stream<Arguments> exceptionProvider() {
+        final var httpErrorCause = new IllegalArgumentException("expected numeric type");
+
+        return Stream.of(
+            Arguments.of(new IllegalArgumentException("", null)),
+            Arguments.of(new IllegalArgumentException("", httpErrorCause)),
+            Arguments.of(new IllegalArgumentException("non-blank", httpErrorCause)),
+            Arguments.of(
+                new IllegalArgumentException("non-blank",
+                    new IllegalArgumentException("other cause"))));
+
+    }
+
     @ParameterizedTest(name = "[{index}]: cause={0}")
     @NullSource
     @MethodSource("causeProvider")
-    void handleAllUncaughtException(final Exception cause) {
+    void handleAllUncaughtExceptionWhenRuntimeExceptionWithCause(final Exception cause) {
         final var exception = new RuntimeException("test", cause);
 
         when(request.getRequest()).thenReturn(servletRequest);
@@ -447,21 +479,22 @@ class RestExceptionHandlerTest {
         final var apiErrors = testExceptionHandler.handleAllUncaughtException(exception, request);
 
         final var expectedError =
-                new ApiError("test", "/path/to/resource", "resource", "ch:service");
+            new ApiError("Service Unavailable: {error}", "/path/to/resource", "resource",
+                "ch:service");
 
-        if (cause != null) {
-            expectedError.addErrorValue("cause", cause.getMessage());
-        }
+        expectedError.addErrorValue("error", "test");
         assertThat(apiErrors.getErrors(), contains(expectedError));
     }
 
     private static Stream<Arguments> causeProvider() {
-        final var cause = new ArithmeticException("DIV/0");
+        final var causeCause = new ArithmeticException("DIV/0");
 
-        return Stream.of(Arguments.of(new PscServiceException("PSCServiceException", cause)),
-                Arguments.of(new TransactionServiceException("TransactionServiceException", cause)),
-                Arguments.of(new CompanyProfileServiceException("CompanyProfileServiceException",
-                        cause)));
+        return Stream.of(
+            Arguments.of(new PscServiceException("PSC details unavailable", causeCause)),
+            Arguments.of(
+                new TransactionServiceException("Transaction details unavailable", causeCause)),
+            Arguments.of(
+                new CompanyProfileServiceException("Company profile details unavailable", null)));
     }
 
     @Test


### PR DESCRIPTION
Due to api-sdk-java handling of CHS service unavailable, it throws
```IllegalArgumentException("")```
with cause
```IllegalArgumentException("expected numeric type but got class uk.gov.companieshouse.api.error.ApiErrorResponse")```

that caused RestExceptionHandler to fail because of the empty exception message.

Fix to handle the exception gracefully and produce a structured error.
Includes logging the probable cause to aid support team diagnosing the problem.